### PR TITLE
Improve profile image alt text

### DIFF
--- a/src/components/content/Header/Header.js
+++ b/src/components/content/Header/Header.js
@@ -243,16 +243,16 @@ function Header() {
 						onMouseLeave={handleMouseLeave}
 					>
 						<button type="button" onClick={handleClick}>
-							<img
-								className={`avatar ${isClicked ? "" : "active"}`}
-								src={profile1}
-								alt="image1"
-							/>
-							<img
-								className={`avatar ${isClicked ? "active" : ""}`}
-								src={profile2}
-								alt="image2"
-							/>
+                                                        <img
+                                                                className={`avatar ${isClicked ? "" : "active"}`}
+                                                                src={profile1}
+                                                                alt="Profile image one"
+                                                        />
+                                                        <img
+                                                                className={`avatar ${isClicked ? "active" : ""}`}
+                                                                src={profile2}
+                                                                alt="Profile image two"
+                                                        />
 						</button>
 						<ChatBubble isVisible={isBubbleVisible} />
 					</div>


### PR DESCRIPTION
## Summary
- update alt text for header profile images

## Testing
- `npm test --silent` *(fails: craco not found)*
- `npm run lint` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e5e349fc8327b5a815a5e9c32d1c

## Summary by Sourcery

Enhancements:
- Replace generic image alt text with descriptive labels for profile images in the header.