### PR TITLE
Fix work card button styling

### DIFF
--- a/src/components/content/About/about.scss
+++ b/src/components/content/About/about.scss
@@ -158,7 +158,7 @@
     p {
       opacity: 0;
       transition: opacity var(--about-transition-duration) ease;
-      font-size: 1.2rem;
+      font-size: 1.4rem;
       line-height: 1.6;
       margin: 0;
       padding: 0 1rem 1rem;
@@ -286,7 +286,7 @@ body.light-theme {
       }
 
       p {
-        font-size: 1.1rem;
+        font-size: 1.3rem;
       }
 
       &.expanded {

--- a/src/components/content/Work/work.scss
+++ b/src/components/content/Work/work.scss
@@ -111,6 +111,7 @@ $mobile-breakpoint: 37.5em;
     @include mix.button-reset;
     @include mix.glass-effect(15px, 0.3); // Increased blur and opacity
     @include mix.clickable;
+    text-align: left;
 
     padding: 2rem 3rem;
     margin: 0.2rem;

--- a/src/components/content/Work/work.scss
+++ b/src/components/content/Work/work.scss
@@ -108,6 +108,7 @@ $mobile-breakpoint: 37.5em;
 
   // Individual Work Item
   &__item {
+    @include mix.button-reset;
     @include mix.glass-effect(15px, 0.3); // Increased blur and opacity
     @include mix.clickable;
 


### PR DESCRIPTION
## Summary
- reset button style on work cards to match previous look

## Testing
- `npm run lint` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410895cd308327922cc0afe39951b3

## Summary by Sourcery

Bug Fixes:
- Reset button style on individual work cards to match prior design