### PR TITLE
Add tools routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,14 +7,18 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import "./sass/main.scss";
 
 import {
-	GOOGLE_SHEETS_CONFIG,
-	NAV_ITEMS,
+  GOOGLE_SHEETS_CONFIG,
+  NAV_ITEMS,
 } from "./components/Core/constants.js";
 // Import Tools components removed temporarily
+import { ToolsSection } from "./components/Tools";
 import { BlurSection } from "./components/effects/Blur";
 import LoadingSequence from "./components/effects/Loading/LoadingSequence.js";
 // Local imports
-import { AuthProvider, useAuth } from "./components/effects/Matrix/AuthContext.js";
+import {
+  AuthProvider,
+  useAuth,
+} from "./components/effects/Matrix/AuthContext.js";
 import Matrix from "./components/effects/Matrix/Matrix.js";
 import FrameEffect from "./components/effects/Loading/FrameEffect.js";
 import MagicComponent from "./components/effects/Moiree/Moiree.js";
@@ -22,103 +26,128 @@ import { About, Header, NavBar, Projects, Work } from "./components/index.js";
 import InfiniteScrollEffect from "./components/effects/InfiniteScrollEffect";
 
 const CustomLoadingComponent = () => (
-	<div className="loading-container">
-		Loading...
-	</div>
+  <div className="loading-container">Loading...</div>
 );
 CustomLoadingComponent.displayName = "CustomLoadingComponent";
 
 const Layout = memo(({ children, navItems, onMatrixActivate, hideNav }) => (
-	<div className="app-layout">
-		<LoadingSequence />
-		<div className="vignette-top" />
-		<div className="vignette-bottom" />
-		<div className="vignette-left" />
-		<div className="vignette-right" />
-		{!hideNav && <NavBar items={navItems} onMatrixActivate={onMatrixActivate} />}
-		<div id="magicContainer">
-			<MagicComponent />
-		</div>
-		<FrameEffect>{children}</FrameEffect>
-	</div>
+  <div className="app-layout">
+    <LoadingSequence />
+    <div className="vignette-top" />
+    <div className="vignette-bottom" />
+    <div className="vignette-left" />
+    <div className="vignette-right" />
+    {!hideNav && (
+      <NavBar items={navItems} onMatrixActivate={onMatrixActivate} />
+    )}
+    <div id="magicContainer">
+      <MagicComponent />
+    </div>
+    <FrameEffect>{children}</FrameEffect>
+  </div>
 ));
 
 Layout.displayName = "Layout";
 
 const HomePageContent = () => {
-	return (
-		<div>
-			<Header />
-			<About />
-			<Projects />
-			<Work />
-			{/* ToolsSection removed temporarily */}
-		</div>
-	);
+  return (
+    <div>
+      <Header />
+      <About />
+      <Projects />
+      <Work />
+      <ToolsSection />
+    </div>
+  );
 };
 
 const AppContent = () => {
-	const [showMatrix, setShowMatrix] = useState(false);
-	const { isUnlocked } = useAuth();
+  const [showMatrix, setShowMatrix] = useState(false);
+  const { isUnlocked } = useAuth();
 
-	// Clean up URL parameter if authenticated
-	useEffect(() => {
-		const urlParams = new URLSearchParams(window.location.search);
-		if (urlParams.has("password")) {
-			// Remove the password parameter from URL
-			urlParams.delete("password");
-			const newUrl =
-				window.location.pathname +
-				(urlParams.toString() ? `?${urlParams.toString()}` : "");
-			window.history.replaceState({}, "", newUrl);
-		}
-	}, []);
+  // Clean up URL parameter if authenticated
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has("password")) {
+      // Remove the password parameter from URL
+      urlParams.delete("password");
+      const newUrl =
+        window.location.pathname +
+        (urlParams.toString() ? `?${urlParams.toString()}` : "");
+      window.history.replaceState({}, "", newUrl);
+    }
+  }, []);
 
-	const handleMatrixActivate = useCallback(() => {
-		setShowMatrix(true);
-	}, []);
+  const handleMatrixActivate = useCallback(() => {
+    setShowMatrix(true);
+  }, []);
 
-	const handleMatrixSuccess = useCallback(() => {
-		setShowMatrix(false);
-	}, []);
+  const handleMatrixSuccess = useCallback(() => {
+    setShowMatrix(false);
+  }, []);
 
-	return (
-		<>
-			<Matrix isVisible={showMatrix} onSuccess={handleMatrixSuccess} />
-			<BrowserRouter>
-				<Suspense fallback={<CustomLoadingComponent />}>
-					<Routes>
-						<Route
-							exact
-							path="/"
-							element={
-								<Layout
-									navItems={NAV_ITEMS}
-									onMatrixActivate={handleMatrixActivate}
-								>
-									<BlurSection as="div" disabled={!isUnlocked}>
-										<InfiniteScrollEffect>
-											<HomePageContent />
-										</InfiniteScrollEffect>
-									</BlurSection>
-								</Layout>
-							}
-						/>
-						{/* Tool routes temporarily removed */}
-						<Route path="*" element={<Navigate to="/" replace />} />
-					</Routes>
-				</Suspense>
-			</BrowserRouter>
-		</>
-	);
+  return (
+    <>
+      <Matrix isVisible={showMatrix} onSuccess={handleMatrixSuccess} />
+      <BrowserRouter>
+        <Suspense fallback={<CustomLoadingComponent />}>
+          <Routes>
+            <Route
+              exact
+              path="/"
+              element={
+                <Layout
+                  navItems={NAV_ITEMS}
+                  onMatrixActivate={handleMatrixActivate}
+                >
+                  <BlurSection as="div" disabled={!isUnlocked}>
+                    <InfiniteScrollEffect>
+                      <HomePageContent />
+                    </InfiniteScrollEffect>
+                  </BlurSection>
+                </Layout>
+              }
+            />
+            <Route
+              path="/tools"
+              element={
+                <Layout
+                  navItems={NAV_ITEMS}
+                  onMatrixActivate={handleMatrixActivate}
+                >
+                  <BlurSection as="div" disabled={!isUnlocked}>
+                    <ToolsSection />
+                  </BlurSection>
+                </Layout>
+              }
+            />
+            <Route
+              path="/tools/:toolId/fullscreen"
+              element={
+                <Layout
+                  navItems={NAV_ITEMS}
+                  onMatrixActivate={handleMatrixActivate}
+                >
+                  <BlurSection as="div" disabled={!isUnlocked}>
+                    <ToolsSection />
+                  </BlurSection>
+                </Layout>
+              }
+            />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Suspense>
+      </BrowserRouter>
+    </>
+  );
 };
 
 const App = () => (
-	<GoogleSheetsProvider config={GOOGLE_SHEETS_CONFIG}>
-		<AuthProvider>
-			<AppContent />
-		</AuthProvider>
-	</GoogleSheetsProvider>
+  <GoogleSheetsProvider config={GOOGLE_SHEETS_CONFIG}>
+    <AuthProvider>
+      <AppContent />
+    </AuthProvider>
+  </GoogleSheetsProvider>
 );
 
 export default App;


### PR DESCRIPTION
## Summary
- render ToolsSection on the home page
- add routes to show ToolsSection and handle fullscreen view

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68410f8508608327a3062d91075f1d45

## Summary by Sourcery

Render the ToolsSection on the home page and introduce dedicated routes for viewing tools and fullscreen tool details

New Features:
- Render ToolsSection on the home page
- Add '/tools' route to display the ToolsSection
- Add '/tools/:toolId/fullscreen' route to handle fullscreen tool view