### PR TITLE
Add tools routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "rimraf": "^3.0.2",
     "styled-components": "^6.1.14",
     "terser-webpack-plugin": "^5.3.10",
+    "tone": "^14.8.39",
     "web-vitals": "^4.2.4"
   },
   "bin": {
@@ -99,6 +100,7 @@
     "imagemin": "^9.0.1",
     "imagemin-mozjpeg": "^10.0.0",
     "imagemin-pngquant": "^10.0.0",
+    "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^15.0.0",
     "markdownlint-cli2": "^0.17.2",
     "npm-check": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react": "^18.2.0",
     "react-db-google-sheets": "^3.0.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.5.0",
     "react-router-dom": "^6.23.0",
     "react-scripts": "^5.0.1",
     "rimraf": "^3.0.2",

--- a/src/App.js
+++ b/src/App.js
@@ -7,14 +7,18 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import "./sass/main.scss";
 
 import {
-	GOOGLE_SHEETS_CONFIG,
-	NAV_ITEMS,
+  GOOGLE_SHEETS_CONFIG,
+  NAV_ITEMS,
 } from "./components/Core/constants.js";
 // Import Tools components removed temporarily
+import { ToolsSection } from "./components/Tools";
 import { BlurSection } from "./components/effects/Blur";
 import LoadingSequence from "./components/effects/Loading/LoadingSequence.js";
 // Local imports
-import { AuthProvider, useAuth } from "./components/effects/Matrix/AuthContext.js";
+import {
+  AuthProvider,
+  useAuth,
+} from "./components/effects/Matrix/AuthContext.js";
 import Matrix from "./components/effects/Matrix/Matrix.js";
 import FrameEffect from "./components/effects/Loading/FrameEffect.js";
 import MagicComponent from "./components/effects/Moiree/Moiree.js";
@@ -22,103 +26,128 @@ import { About, Header, NavBar, Projects, Work } from "./components/index.js";
 import InfiniteScrollEffect from "./components/effects/InfiniteScrollEffect";
 
 const CustomLoadingComponent = () => (
-	<div className="loading-container">
-		Loading...
-	</div>
+  <div className="loading-container">Loading...</div>
 );
 CustomLoadingComponent.displayName = "CustomLoadingComponent";
 
 const Layout = memo(({ children, navItems, onMatrixActivate, hideNav }) => (
-	<div className="app-layout">
-		<LoadingSequence />
-		<div className="vignette-top" />
-		<div className="vignette-bottom" />
-		<div className="vignette-left" />
-		<div className="vignette-right" />
-		{!hideNav && <NavBar items={navItems} onMatrixActivate={onMatrixActivate} />}
-		<div id="magicContainer">
-			<MagicComponent />
-		</div>
-		<FrameEffect>{children}</FrameEffect>
-	</div>
+  <div className="app-layout">
+    <LoadingSequence />
+    <div className="vignette-top" />
+    <div className="vignette-bottom" />
+    <div className="vignette-left" />
+    <div className="vignette-right" />
+    {!hideNav && (
+      <NavBar items={navItems} onMatrixActivate={onMatrixActivate} />
+    )}
+    <div id="magicContainer">
+      <MagicComponent />
+    </div>
+    <FrameEffect>{children}</FrameEffect>
+  </div>
 ));
 
 Layout.displayName = "Layout";
 
 const HomePageContent = () => {
-	return (
-		<div>
-			<Header />
-			<About />
-			<Projects />
-			<Work />
-			{/* ToolsSection removed temporarily */}
-		</div>
-	);
+  return (
+    <div>
+      <Header />
+      <About />
+      <Projects />
+      <Work />
+      <ToolsSection />
+    </div>
+  );
 };
 
 const AppContent = () => {
-	const [showMatrix, setShowMatrix] = useState(false);
-	const { isUnlocked } = useAuth();
+  const [showMatrix, setShowMatrix] = useState(false);
+  const { isUnlocked } = useAuth();
 
-	// Clean up URL parameter if authenticated
-	useEffect(() => {
-		const urlParams = new URLSearchParams(window.location.search);
-		if (urlParams.has("password")) {
-			// Remove the password parameter from URL
-			urlParams.delete("password");
-			const newUrl =
-				window.location.pathname +
-				(urlParams.toString() ? `?${urlParams.toString()}` : "");
-			window.history.replaceState({}, "", newUrl);
-		}
-	}, []);
+  // Clean up URL parameter if authenticated
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has("password")) {
+      // Remove the password parameter from URL
+      urlParams.delete("password");
+      const newUrl =
+        window.location.pathname +
+        (urlParams.toString() ? `?${urlParams.toString()}` : "");
+      window.history.replaceState({}, "", newUrl);
+    }
+  }, []);
 
-	const handleMatrixActivate = useCallback(() => {
-		setShowMatrix(true);
-	}, []);
+  const handleMatrixActivate = useCallback(() => {
+    setShowMatrix(true);
+  }, []);
 
-	const handleMatrixSuccess = useCallback(() => {
-		setShowMatrix(false);
-	}, []);
+  const handleMatrixSuccess = useCallback(() => {
+    setShowMatrix(false);
+  }, []);
 
-	return (
-		<>
-			<Matrix isVisible={showMatrix} onSuccess={handleMatrixSuccess} />
-			<BrowserRouter>
-				<Suspense fallback={<CustomLoadingComponent />}>
-					<Routes>
-						<Route
-							exact
-							path="/"
-							element={
-								<Layout
-									navItems={NAV_ITEMS}
-									onMatrixActivate={handleMatrixActivate}
-								>
-									<BlurSection as="div" disabled={!isUnlocked}>
-										<InfiniteScrollEffect>
-											<HomePageContent />
-										</InfiniteScrollEffect>
-									</BlurSection>
-								</Layout>
-							}
-						/>
-						{/* Tool routes temporarily removed */}
-						<Route path="*" element={<Navigate to="/" replace />} />
-					</Routes>
-				</Suspense>
-			</BrowserRouter>
-		</>
-	);
+  return (
+    <>
+      <Matrix isVisible={showMatrix} onSuccess={handleMatrixSuccess} />
+      <BrowserRouter>
+        <Suspense fallback={<CustomLoadingComponent />}>
+          <Routes>
+            <Route
+              exact
+              path="/"
+              element={
+                <Layout
+                  navItems={NAV_ITEMS}
+                  onMatrixActivate={handleMatrixActivate}
+                >
+                  <BlurSection as="div" disabled={!isUnlocked}>
+                    <InfiniteScrollEffect>
+                      <HomePageContent />
+                    </InfiniteScrollEffect>
+                  </BlurSection>
+                </Layout>
+              }
+            />
+            <Route
+              path="/tools"
+              element={
+                <Layout
+                  navItems={NAV_ITEMS}
+                  onMatrixActivate={handleMatrixActivate}
+                >
+                  <BlurSection as="div" disabled={!isUnlocked}>
+                    <ToolsSection />
+                  </BlurSection>
+                </Layout>
+              }
+            />
+            <Route
+              path="/tools/:toolId/fullscreen"
+              element={
+                <Layout
+                  navItems={NAV_ITEMS}
+                  onMatrixActivate={handleMatrixActivate}
+                >
+                  <BlurSection as="div" disabled={!isUnlocked}>
+                    <ToolsSection />
+                  </BlurSection>
+                </Layout>
+              }
+            />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Suspense>
+      </BrowserRouter>
+    </>
+  );
 };
 
 const App = () => (
-	<GoogleSheetsProvider config={GOOGLE_SHEETS_CONFIG}>
-		<AuthProvider>
-			<AppContent />
-		</AuthProvider>
-	</GoogleSheetsProvider>
+  <GoogleSheetsProvider config={GOOGLE_SHEETS_CONFIG}>
+    <AuthProvider>
+      <AppContent />
+    </AuthProvider>
+  </GoogleSheetsProvider>
 );
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -93,7 +93,6 @@ const AppContent = () => {
         <Suspense fallback={<CustomLoadingComponent />}>
           <Routes>
             <Route
-              exact
               path="/"
               element={
                 <Layout

--- a/src/components/Tools/ConflictMediation/NeedsAssessment.js
+++ b/src/components/Tools/ConflictMediation/NeedsAssessment.js
@@ -325,7 +325,6 @@ const NeedsAssessment = ({ onNeedsSelected }) => {
                                                         selectedLevel === level ? "selected" : ""
                                                 }`}
                                                 onClick={() => handleLevelClick(level)}
-                                                disabled={disabled}
                                         >
 						<div className="category-header">
 							<span className="category-emoji">{level.emoji}</span>
@@ -350,7 +349,6 @@ const NeedsAssessment = ({ onNeedsSelected }) => {
                                                                 }`}
                                                                 type="button"
                                                                 onClick={() => handleNeedClick(need)}
-                                                                disabled={disabled}
                                                         >
 								{need}
                                                         </button>

--- a/src/components/Tools/index.ts
+++ b/src/components/Tools/index.ts
@@ -1,3 +1,5 @@
+import type { ComponentType } from 'react';
+
 // Export all tool components
 // Note: These imports will be updated as we refactor each component
 export { default as BingoGame } from './Bingo/BingoGame.js'; 
@@ -8,8 +10,6 @@ export { FullscreenWrapper, FullscreenToolStyles } from './ToolsSection/Fullscre
 export { default as Snake } from './Snake/SnakeGame.js';
 export { default as ConflictMediation } from './ConflictMediation/ConflictMediation.js';
 export { NeedsAssessment } from './ConflictMediation';
-
-import type { ComponentType } from 'react';
 
 // Export types
 export type ToolId = 'bingo' | 'snake' | 'conflict-mediation';


### PR DESCRIPTION
## Summary
- render ToolsSection on the home page
- add routes to show ToolsSection and handle fullscreen view

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68410f8508608327a3062d91075f1d45

## Summary by Sourcery

Render ToolsSection on the homepage and add routing for tools listing and fullscreen tool views.

New Features:
- Render ToolsSection on the homepage
- Add "/tools" and "/tools/:toolId/fullscreen" routes to display ToolsSection and handle fullscreen view