### PR TITLE
Fix tool style conflicts

### DIFF
--- a/src/components/Tools/ConflictMediation/styles/conflict-mediation.scss
+++ b/src/components/Tools/ConflictMediation/styles/conflict-mediation.scss
@@ -9,8 +9,10 @@
 // Import shared styles
 @use "../../shared/styles/index.scss" as tool;
 
-// Add a general heading style rule after the imports
-h1, h2, h3 {
+// Scope heading styles to this tool
+.conflict-mediation h1,
+.conflict-mediation h2,
+.conflict-mediation h3 {
   text-transform: uppercase;
 }
 

--- a/src/components/Tools/Snake/SnakeGame.js
+++ b/src/components/Tools/Snake/SnakeGame.js
@@ -241,6 +241,12 @@ class SoundManager {
                         const toneModule = await import("tone");
                         Tone = toneModule.default || toneModule;
                 }
+        
+                // Ensure synthesizers are properly initialized before continuing
+                if (!Tone) {
+                        console.warn("Tone.js could not be initialized. Audio will be disabled.");
+                        return;
+                }
 
                 if (!this.foodSynth) {
                         this.foodSynth = new Tone.Synth({

--- a/src/components/Tools/Snake/SnakeGame.js
+++ b/src/components/Tools/Snake/SnakeGame.js
@@ -238,7 +238,8 @@ class SoundManager {
 
         async initialize() {
                 if (!Tone) {
-                        Tone = await import("tone");
+                        const toneModule = await import("tone");
+                        Tone = toneModule.default || toneModule;
                 }
 
                 if (!this.foodSynth) {

--- a/src/components/Tools/Snake/styles/snake.scss
+++ b/src/components/Tools/Snake/styles/snake.scss
@@ -5,8 +5,10 @@
 @use "../../../../sass/breakpoints" as bp;
 @use "../../../../sass/tokens" as tokens;
 
-// Global header styles
-h1, h2, h3 {
+// Scope header styles to the snake game
+.snake-game-container h1,
+.snake-game-container h2,
+.snake-game-container h3 {
   text-transform: uppercase;
 }
 

--- a/src/components/Tools/shared/styles/index.scss
+++ b/src/components/Tools/shared/styles/index.scss
@@ -9,8 +9,11 @@
 @use '../../../../sass/functions' as fn;
 @use '../../../../sass/tokens' as tokens; // Import tokens
 
-// Global header styles for all tools
-h1, h2, h3, h4 {
+// Tool-specific header styles
+.tool-content h1,
+.tool-content h2,
+.tool-content h3,
+.tool-content h4 {
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
## Summary
- scope heading styles for tool components to avoid global clashes

## Testing
- `npx -y biome check --write .`

------
https://chatgpt.com/codex/tasks/task_e_6841248d140883278c389a949e91df02

## Summary by Sourcery

Scope header styles in tool components to their container classes to eliminate global style collisions and improve compatibility of the Tone import in the Snake game

Bug Fixes:
- Fix dynamic import of Tone library in SnakeGame to handle default exports correctly

Enhancements:
- Scope global heading styles in shared and tool-specific SCSS files to their respective container classes to prevent style clashes