### PR TITLE
Add aria labels for Bingo year buttons

### DIFF
--- a/src/components/Tools/Bingo/BingoGame.js
+++ b/src/components/Tools/Bingo/BingoGame.js
@@ -531,6 +531,7 @@ const BingoContent = memo(({ isFullscreen }) => {
               type="button"
               className={year === y ? "active" : ""}
               onClick={() => handleYearChange(y)}
+              aria-label={`Select ${y}`}
             >
               {y}
             </button>


### PR DESCRIPTION
## Summary
- improve year selector buttons for BingoGame accessibility

## Testing
- `npm run check` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412a29f3588327ae253447154931fd

## Summary by Sourcery

Enhancements:
- Add aria-label attributes to year selector buttons in the BingoGame component to improve accessibility