### PR TITLE
Add card typography mixin

### DIFF
--- a/src/components/Tools/Bingo/styles/bingo.scss
+++ b/src/components/Tools/Bingo/styles/bingo.scss
@@ -55,7 +55,7 @@
   gap: 1rem;
   
   h1 {
-    font-size: 2rem;
+    font-size: tokens.font-size('xxl');
     color: var(--color-text);
     text-align: center;
     margin: 0;
@@ -96,15 +96,14 @@
   }
   
   .progress-summary {
+    @include shared.card-typography;
     text-align: center;
     color: var(--color-text);
-    
+
     h3 {
-      font-size: 1.2rem;
-      margin-bottom: 0.5rem;
       margin-top: 0;
     }
-    
+
     p {
       margin: 0;
     }
@@ -178,17 +177,17 @@
   
   .text {
     font-weight: 600;
-    font-size: 0.9rem;
+    font-size: tokens.font-size('sm');
     color: var(--color-text);
     margin-bottom: 0.25rem;
-    
+
     @include mix.respond("medium") {
-      font-size: 0.8rem;
+      font-size: tokens.font-size('xs');
     }
   }
   
   .description {
-    font-size: 0.7rem;
+    font-size: tokens.font-size('xs');
     color: var(--color-text-light);
     opacity: 0;
     transition: opacity var(--about-transition-duration) var(--theme-transition-timing);
@@ -214,7 +213,7 @@
     top: 0.25rem;
     right: 0.25rem;
     color: var(--color-sage);
-    font-size: 1rem;
+    font-size: tokens.font-size('md');
   }
 }
 
@@ -288,7 +287,7 @@
   color: var(--color-text);
 
   i {
-    font-size: 2rem;
+    font-size: tokens.font-size('xxl');
     color: var(--color-sage);
     animation: rotate 1s linear infinite;
   }
@@ -305,7 +304,7 @@
   box-shadow: var(--about-glass-shadow);
 
   h3 {
-    font-size: 1.5rem;
+    font-size: tokens.font-size('xl');
     margin-bottom: 1rem;
   }
 
@@ -337,12 +336,12 @@
   .bingo-game {
     .bingo-header {
       h1 {
-        font-size: 1.5rem;
+        font-size: tokens.font-size('xl');
       }
-      
+
       .year-selector button {
         padding: 0.4rem 0.8rem;
-        font-size: 0.9rem;
+        font-size: tokens.font-size('sm');
       }
     }
   }
@@ -376,7 +375,7 @@
 
 @include mix.respond('medium') {
   .bingo-card__cell {
-    font-size: 0.9rem;
+    font-size: tokens.font-size('sm');
   }
 }
 

--- a/src/components/Tools/Bingo/styles/bingo.scss
+++ b/src/components/Tools/Bingo/styles/bingo.scss
@@ -1,4 +1,4 @@
-@use "../../shared/styles/index.scss" as shared;
+@use "../../shared/styles/index.scss" as tool;
 // @use "../../../../sass/variables" as vars; // Removed in favor of tokens
 @use "../../../../sass/mixins" as mix;
 @use "../../../../sass/functions" as fn;
@@ -96,7 +96,7 @@
   }
   
   .progress-summary {
-    @include shared.card-typography;
+    @include tool.card-typography;
     text-align: center;
     color: var(--color-text);
 

--- a/src/components/Tools/Bingo/styles/index.scss
+++ b/src/components/Tools/Bingo/styles/index.scss
@@ -5,7 +5,7 @@
 @use "../../../../sass/breakpoints" as bp;
 
 // Import shared styles
-@use "../../shared/styles/index.scss" as shared;
+@use "../../shared/styles/index.scss" as tool;
 
 // Import bingo styles
 @use './bingo.scss';
@@ -22,3 +22,4 @@
   --bingo-will-change-transform: transform;
   --bingo-will-change-both: transform, opacity;
 } 
+

--- a/src/components/Tools/ConflictMediation/styles/conflict-mediation.scss
+++ b/src/components/Tools/ConflictMediation/styles/conflict-mediation.scss
@@ -229,30 +229,28 @@
         box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
       }
 
+      @include tool.card-typography;
+
       h2 {
-        font-size: 2.5rem;
         color: white;
         text-align: center;
-        margin-bottom: 1rem;
+        margin-bottom: tokens.spacing('sm');
         font-weight: 600;
       }
 
       h3 {
-        font-size: 1.8rem;
         color: rgba(255, 215, 0, 0.9);
-        margin-bottom: 1.5rem;
+        margin-bottom: tokens.spacing('md');
         padding-bottom: 0.5rem;
         border-bottom: 2px solid rgba(255, 215, 0, 0.2);
       }
 
       h4 {
-        font-size: 1.4rem;
         color: white;
-        margin-bottom: 1rem;
+        margin-bottom: tokens.spacing('sm');
       }
 
       .view-content {
-        font-size: 1.3rem;
         line-height: 1.6;
         color: rgba(255, 255, 255, 0.9);
         white-space: pre-wrap;
@@ -268,7 +266,7 @@
           border: 1px solid rgba(255, 255, 255, 0.2);
           padding: 0.75rem 1.25rem;
           border-radius: 2rem;
-          font-size: 1.2rem;
+          font-size: tokens.font-size('lg');
           color: white;
           transition: all 0.3s ease;
           
@@ -280,6 +278,7 @@
       }
 
       .style-block {
+        @include tool.card-typography;
         background: rgba(255, 255, 255, 0.05);
         border-radius: 0.75rem;
         padding: 1.5rem;
@@ -298,20 +297,19 @@
         }
         
         p {
-          font-size: 1.2rem;
           line-height: 1.6;
           color: rgba(255, 255, 255, 0.9);
         }
       }
 
       .perspective-block {
+        @include tool.card-typography;
         background: rgba(255, 255, 255, 0.05);
         border-radius: 0.75rem;
         padding: 1.5rem;
         margin-bottom: 1.5rem;
-        
+
         p {
-          font-size: 1.2rem;
           line-height: 1.6;
           color: rgba(255, 255, 255, 0.9);
           
@@ -422,7 +420,7 @@
   
   .emotion-example {
     color: rgba(255, 255, 255, 0.9) !important;
-    font-size: 1.2rem;
+    font-size: tokens.font-size('lg');
     margin-top: 0.25rem;
     margin-bottom: 0.5rem;
     padding: 0.5rem;
@@ -736,7 +734,7 @@
         margin-bottom: 1.5rem;
         
         .narrative-text {
-          font-size: 1.2rem;
+          font-size: tokens.font-size('lg');
           line-height: 1.7;
           color: rgba(255, 255, 255, 0.95);
           margin-bottom: 1.5rem;

--- a/src/components/Tools/ConflictMediation/styles/conflict-mediation.scss
+++ b/src/components/Tools/ConflictMediation/styles/conflict-mediation.scss
@@ -278,7 +278,7 @@
       }
 
       .style-block {
-        @include tool.card-typography;
+        @include shared.card-typography;
         background: rgba(255, 255, 255, 0.05);
         border-radius: 0.75rem;
         padding: 1.5rem;

--- a/src/components/Tools/ToolsSection/styles/index.scss
+++ b/src/components/Tools/ToolsSection/styles/index.scss
@@ -100,13 +100,14 @@ body.is-fullscreen {
   }
   
   &__icon {
-    font-size: 2rem;
-    margin-bottom: 1rem;
+    font-size: tokens.font-size('xxl');
+    margin-bottom: tokens.spacing('md');
     color: var(--color-sage);
   }
-  
+
   &__content {
     text-align: center;
+    @include tool.card-typography;
   }
   
   &__title {
@@ -199,9 +200,9 @@ body.is-fullscreen {
 
 .loading-wrapper {
   @extend .error-container;
-  
+
   i {
-    font-size: 2rem;
+    font-size: tokens.font-size('xxl');
     animation: rotate 1s linear infinite;
   }
-} 
+}

--- a/src/components/Tools/shared/styles/index.scss
+++ b/src/components/Tools/shared/styles/index.scss
@@ -8,6 +8,7 @@
 @use '../../../../sass/breakpoints' as bp;
 @use '../../../../sass/functions' as fn;
 @use '../../../../sass/tokens' as tokens; // Import tokens
+@use '../../../../sass/typography' as typography;
 
 // Tool-specific header styles
 .tool-content h1,
@@ -87,7 +88,7 @@
   // Card description text
   p {
     font-size: tokens.font-size('md');
-    line-height: 1.5;
+    @include typography.line-height('normal');
   }
 
   // Card metadata

--- a/src/components/Tools/shared/styles/index.scss
+++ b/src/components/Tools/shared/styles/index.scss
@@ -74,6 +74,30 @@
   }
 }
 
+// Typography for standard card components
+@mixin card-typography {
+  // Card titles
+  h2,
+  h3 {
+    font-size: tokens.font-size('lg');
+    font-weight: tokens.font-weight('semibold');
+    margin-bottom: tokens.spacing('sm');
+  }
+
+  // Card description text
+  p {
+    font-size: tokens.font-size('md');
+    line-height: 1.5;
+  }
+
+  // Card metadata
+  .metadata,
+  .card-info {
+    font-size: tokens.font-size('sm');
+    color: var(--color-text-light);
+  }
+}
+
 // Button Mixins
 @mixin tool-button {
   display: inline-flex;


### PR DESCRIPTION
### **User description**
## Summary
- implement `card-typography` mixin in shared tool styles
- use the mixin for tool card content and error/summary sections
- replace direct font sizes with token-based values

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412a304374832780235c52dfabe045


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce `card-typography` mixin for card content styling
  - Centralizes card heading, paragraph, and metadata styles
  - Promotes token-based, consistent typography across tools

- Refactor SCSS files to use the new mixin and token-based font sizes
  - Replace hardcoded font sizes with `tokens.font-size` in multiple components
  - Apply `card-typography` mixin to card content, error, and summary sections

- Improve maintainability and consistency of tool card UI styles


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.scss</strong><dd><code>Add card-typography mixin for unified card styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Tools/shared/styles/index.scss

<li>Added <code>card-typography</code> mixin for standardized card typography<br> <li> Defined heading, paragraph, and metadata styles using tokens


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/Personal-Website/pull/109/files#diff-c921e65ae42c8b618770ad056f66f0bf7e54760eb446064f6072cbea71f0276a">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bingo.scss</strong><dd><code>Refactor Bingo styles to use tokens and card-typography</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/components/Tools/Bingo/styles/bingo.scss

<li>Replaced hardcoded font sizes with <code>tokens.font-size</code> throughout<br> <li> Applied <code>shared.card-typography</code> mixin to <code>.progress-summary</code><br> <li> Updated responsive font sizes to use tokens


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/Personal-Website/pull/109/files#diff-62937342dcb9aaa3423a093c76549ff045ec4a78debe71b92db8cda3e4263573">+15/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conflict-mediation.scss</strong><dd><code>Use card-typography mixin and tokens in Conflict Mediation styles</code></dd></summary>
<hr>

src/components/Tools/ConflictMediation/styles/conflict-mediation.scss

<li>Applied <code>tool.card-typography</code> mixin to card and block elements<br> <li> Replaced hardcoded font sizes with <code>tokens.font-size</code> in emotion tags, <br>narrative, etc.<br> <li> Improved spacing using token-based values


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/Personal-Website/pull/109/files#diff-45018ba647c2c13ae66e5b1cb6560504c76f9c3c6edfb69bb7034c8a0b304b39">+11/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.scss</strong><dd><code>Refactor ToolsSection styles to use tokens and card-typography</code></dd></summary>
<hr>

src/components/Tools/ToolsSection/styles/index.scss

<li>Updated icon and loading font sizes to use <code>tokens.font-size</code><br> <li> Applied <code>tool.card-typography</code> mixin to tool card content<br> <li> Improved margin and spacing using tokens


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/Personal-Website/pull/109/files#diff-65d64c548bd608b6a8294c21478f39ac411d9e9e24ac18c6ee2221170abac378">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>