### PR TITLE
Fix missing SASS namespace

### DIFF
--- a/src/components/Tools/ConflictMediation/styles/conflict-mediation.scss
+++ b/src/components/Tools/ConflictMediation/styles/conflict-mediation.scss
@@ -278,7 +278,7 @@
       }
 
       .style-block {
-        @include shared.card-typography;
+        @include tool.card-typography;
         background: rgba(255, 255, 255, 0.05);
         border-radius: 0.75rem;
         padding: 1.5rem;


### PR DESCRIPTION
## Summary
- fix SASS mixin namespace typo in conflict mediation styles

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm run sass:check` *(fails: sass not found)*
- `npm test -- -u` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841314409908327b2457dbde4f9035c

## Summary by Sourcery

Bug Fixes:
- Correct the card-typography mixin include to use tool.card-typography instead of shared.card-typography