### PR TITLE
Fix undefined mixin in BingoGame styles

### DIFF
--- a/src/components/Tools/Bingo/BingoGame.module.scss
+++ b/src/components/Tools/Bingo/BingoGame.module.scss
@@ -83,7 +83,7 @@
   box-shadow: 0 4px 12px rgb(0 0 0 / 20%);
   will-change: transform;
 
-  @include bp.max(768px) {
+  @media (max-width: 768px) {
     gap: 0.5rem;
     padding: 1rem;
   }
@@ -169,7 +169,7 @@
     color: var(--tool-text);
   }
 
-  @include bp.max(768px) {
+  @media (max-width: 768px) {
     .text {
       font-size: 0.8rem;
     }


### PR DESCRIPTION
## Summary
- replace `bp.max` mixin calls with standard media queries

## Testing
- `npm test -- -w=0` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841328c9fa48327bf8087b8497403eb

## Summary by Sourcery

Bug Fixes:
- Replace undefined `bp.max` mixin calls with `@media (max-width: 768px)` in BingoGame.module.scss for consistent mobile styling.