### PR TITLE
Refactor Tools grid with Tailwind

### DIFF
--- a/src/components/Tools/ToolsSection/ToolsSection.js
+++ b/src/components/Tools/ToolsSection/ToolsSection.js
@@ -14,20 +14,6 @@ import { FullscreenWrapper } from "./FullscreenWrapper";
 import { useKeyboardNavigation } from "../shared/hooks";
 import "./styles/index.scss";
 
-// Common animation configurations
-const ANIMATION_CONFIG = {
-	duration: {
-		default: 0.3,
-		enter: 0.5,
-		exit: 0.3,
-	},
-	ease: [0.4, 0, 0.2, 1],
-};
-
-// Animation variants removed as not used in this file
-
-// SVG Icons removed as they're already defined in FullscreenWrapper.js
-
 // Enhanced loading fallback
 const LoadingFallback = memo(() => (
 	<div className="loading-wrapper">
@@ -129,31 +115,25 @@ class ErrorBoundary extends React.Component {
 
 // Tool card component
 const ToolCard = memo(({ tool, isSelected, onSelect }) => {
-	const { ref, inView } = useInView({
-		threshold: 0.1,
-		triggerOnce: true,
-	});
+        const { ref, inView } = useInView({
+                threshold: 0.1,
+                triggerOnce: true,
+        });
 
-	return (
-		<motion.div
-			ref={ref}
-			className={`tool-card ${isSelected ? 'tool-card--selected' : ''}`}
-			onClick={() => onSelect(tool.id)}
-			whileHover={{ scale: 1.05 }}
-			whileTap={{ scale: 0.95 }}
-			initial={{ opacity: 0, y: 20 }}
-			animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-			transition={{ duration: 0.3 }}
-		>
-			<div className="tool-card__icon">
-                                <i className={tool.icon} />
-			</div>
-			<div className="tool-card__content">
-				<h3 className="tool-card__title">{tool.title}</h3>
-				<p className="tool-card__description">{tool.description}</p>
-			</div>
-		</motion.div>
-	);
+        return (
+                <motion.button
+                        ref={ref}
+                        onClick={() => onSelect(tool.id)}
+                        className={`flex flex-col items-center text-center p-6 rounded-lg shadow-md bg-gray-800/60 hover:-translate-y-1 hover:shadow-lg transition-transform focus:outline-none ${isSelected ? 'ring-2 ring-[var(--color-sage)]' : ''}`}
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+                        transition={{ duration: 0.3 }}
+                >
+                        <i className={`${tool.icon} text-3xl text-[var(--color-sage)] mb-2`} />
+                        <h3 className="text-lg font-semibold text-[var(--color-text)]">{tool.title}</h3>
+                        <p className="text-sm text-[var(--color-text-light)]">{tool.description}</p>
+                </motion.button>
+        );
 });
 
 ToolCard.displayName = "ToolCard";
@@ -233,7 +213,7 @@ const ToolsSection = () => {
 				</div>
 			</div>
 
-			<div className="tool-container">
+                        <div className="mx-auto grid max-w-5xl gap-6 px-4 sm:grid-cols-2 lg:grid-cols-3">
 				{tools.map((tool) => (
 					<ToolCard
 						key={tool.id}
@@ -244,7 +224,7 @@ const ToolsSection = () => {
 				))}
 			</div>
 
-			<div className="tool-content-container">
+                        <div className="tool-content-container mt-8">
 				<AnimatePresence mode="wait">
 					{SelectedToolComponent && (
 						<ErrorBoundary key={selectedTool}>


### PR DESCRIPTION
### **User description**
## Summary
- simplify `ToolsSection` card markup and animations
- use Tailwind classes for responsive grid and card styling
- tweak content spacing for a cleaner layout

## Testing
- `npm test --silent` *(fails: craco not found)*
- `npm run lint` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841356b3bb483279219f7fa16fda03a


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored `ToolsSection` layout using Tailwind CSS classes

- Simplified `ToolCard` markup and switched to button element

- Improved responsive grid and card styling for clarity

- Enhanced accessibility and interaction feedback


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ToolsSection.js</strong><dd><code>Refactor ToolsSection and ToolCard with Tailwind and accessibility</code></dd></summary>
<hr>

src/components/Tools/ToolsSection/ToolsSection.js

<li>Replaced custom grid and card classes with Tailwind utility classes<br> <li> Changed <code>ToolCard</code> from div to motion.button for accessibility<br> <li> Simplified card markup, improved spacing and visual feedback<br> <li> Updated grid container for responsive layout using Tailwind


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/Personal-Website/pull/113/files#diff-1699f21069d6802c509d589234fd4b9c5931bdcdb46cc4050f269c1099575f02">+21/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>