### PR TITLE
Add AVIF image compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,6 @@ In the future, I plan to continue updating the blog and publications sections wi
 
 - Run `./setup.sh` after cloning to install dependencies.
 - Run `npm run compress-images` to write optimized copies to `src/assets/images/optimized`.
+- The same command also converts JPEG/PNG files to `.avif` using `imagemin-avif` (requires Node.js 18 or later).
 - A pre-commit hook runs this command automatically.
 - Consider using Git LFS for large image files.

--- a/compress-images.js
+++ b/compress-images.js
@@ -5,6 +5,7 @@ const path = require("node:path");
 const loadImagemin = async () => (await import('imagemin')).default;
 const loadMozjpeg = async () => (await import('imagemin-mozjpeg')).default;
 const loadPngquant = async () => (await import('imagemin-pngquant')).default;
+const loadAvif = async () => (await import('imagemin-avif')).default;
 
 const imagesDir = path.resolve(__dirname, 'src', 'assets', 'images');
 const outputDir = path.join(imagesDir, 'optimized');
@@ -24,6 +25,7 @@ async function compressImages() {
   const imagemin = await loadImagemin();
   const imageminMozjpeg = await loadMozjpeg();
   const imageminPngquant = await loadPngquant();
+  const imageminAvif = await loadAvif();
 
   try {
     const allFiles = await listFiles(imagesDir);
@@ -45,10 +47,18 @@ async function compressImages() {
               imageminPngquant({ quality: [0.6, 0.8] }),
             ],
           });
+          const avifOut = await imagemin.buffer(data, {
+            plugins: [imageminAvif({ quality: 50 })],
+          });
           const rel = path.relative(imagesDir, file);
           const dest = path.join(outputDir, rel);
+          const avifDest = path.join(
+            outputDir,
+            rel.replace(/\.(jpe?g|png)$/i, '.avif'),
+          );
           await fs.mkdir(path.dirname(dest), { recursive: true });
           await fs.writeFile(dest, out);
+          await fs.writeFile(avifDest, avifOut);
         } catch (err) {
           console.error(`Failed to compress ${file}:`, err);
         }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "got": "^11.8.6",
     "husky": "^8.0.0",
     "imagemin": "^9.0.1",
+    "imagemin-avif": "^0.1.6",
     "imagemin-mozjpeg": "^10.0.0",
     "imagemin-pngquant": "^10.0.0",
     "jest-watch-typeahead": "^2.2.2",


### PR DESCRIPTION
## Summary
- add imagemin-avif dev dependency
- convert JPEG/PNG to AVIF in compress-images.js
- document AVIF conversion in README

## Testing
- `npm run compress-images`


------
https://chatgpt.com/codex/tasks/task_e_685e27235aac83279df9e90fbde9b58b

## Summary by Sourcery

Add AVIF image compression support to the image optimization script

New Features:
- Convert JPEG and PNG files to AVIF format during image compression

Build:
- Add imagemin-avif as a development dependency

Documentation:
- Update README to document AVIF conversion and Node.js 18+ requirement