### PR TITLE
feat: restore tools section

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,7 @@ import {
   Shop,
   Work,
 } from "./components/index.js";
+import { ToolsSection } from "./components/Tools";
 
 // * Loading fallback
 const CustomLoadingComponent = () => (
@@ -75,7 +76,7 @@ const HomePageContent = () => (
     <About />
     <Projects />
     <Work />
-    {/* {ENABLE_TOOLS && <ToolsSection />} */}
+    <ToolsSection />
   </div>
 );
 
@@ -144,9 +145,36 @@ const MainRoutes = ({
           </Layout>
         }
       />
-      {/* {ENABLE_TOOLS && (
-    <Route ... />
-    )} */}
+      <Route
+        path="/tools"
+        element={
+          <Layout
+            navItems={navItems}
+            onMatrixActivate={onMatrixActivate}
+            onShopActivate={onShopActivate}
+            isInShop={currentIsInShop}
+          >
+            <ShopBlurWrapper isShopMode={isShopMode} isUnlocked={isUnlocked}>
+              <ToolsSection />
+            </ShopBlurWrapper>
+          </Layout>
+        }
+      />
+      <Route
+        path="/tools/:toolId/fullscreen"
+        element={
+          <Layout
+            navItems={navItems}
+            onMatrixActivate={onMatrixActivate}
+            onShopActivate={onShopActivate}
+            isInShop={currentIsInShop}
+          >
+            <ShopBlurWrapper isShopMode={isShopMode} isUnlocked={isUnlocked}>
+              <ToolsSection />
+            </ShopBlurWrapper>
+          </Layout>
+        }
+      />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );

--- a/src/components/Core/constants.js
+++ b/src/components/Core/constants.js
@@ -11,4 +11,5 @@ export const NAV_ITEMS = {
   About: "/#about",
   Projects: "/#projects",
   Work: "/#work",
+  Tools: "/#tools",
 };

--- a/src/components/effects/Loading/LoadingSequence.js
+++ b/src/components/effects/Loading/LoadingSequence.js
@@ -34,17 +34,13 @@ const LoadingSequence = ({ onComplete }) => {
       magicContainer.style.opacity = "0";
     }
 
-    let t1;
-    let t2;
-
-    // Start revealing content
-    t1 = setTimeout(() => {
+    const t1 = setTimeout(() => {
       if (maskTop) maskTop.style.transform = "scaleY(0)";
       if (maskBottom) maskBottom.style.transform = "scaleY(0)";
     }, 500);
 
     // Fade in magic container
-    t2 = setTimeout(() => {
+    const t2 = setTimeout(() => {
       if (magicContainer) {
         magicContainer.style.opacity = "0.2";
       }

--- a/src/components/effects/Moiree/Moiree.js
+++ b/src/components/effects/Moiree/Moiree.js
@@ -284,7 +284,7 @@ function Magic(containerEl) {
       document.body.removeEventListener("mousemove", onMove);
       document.body.removeEventListener("mouseup", randomizeColors);
     } catch {}
-    if (gl && gl.canvas && gl.canvas.parentNode) {
+    if (gl?.canvas?.parentNode) {
       gl.canvas.parentNode.removeChild(gl.canvas);
     }
   };


### PR DESCRIPTION
## Summary
- reinstate ToolsSection in the home page and add dedicated routes
- expose Tools in navigation
- fix minor lint issues in loading sequence and moiree effects

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b268e803b0832782a79de0724fa89c

## Summary by Sourcery

Restore and expose the Tools section by adding it back to the homepage, creating dedicated routes, and updating navigation; also apply minor lint and cleanup enhancements in loading and moiree effects.

New Features:
- Reinstate ToolsSection on the homepage
- Add dedicated "/tools" and "/tools/:toolId/fullscreen" routes rendering ToolsSection
- Include Tools in the main navigation items

Enhancements:
- Refactor loading sequence timers to use const and remove unused variable declarations
- Use optional chaining for gl.canvas cleanup in the Moiree effect