### PR TITLE
Debug login site issue

### DIFF
--- a/src/components/Tools/ToolsSection/ToolsSection.js
+++ b/src/components/Tools/ToolsSection/ToolsSection.js
@@ -159,11 +159,25 @@ const ToolsSection = () => {
   const { isUnlocked } = useAuth();
   // Make isUnlocked usage more obvious to the linter
   const toolsAccessible = isUnlocked;
+  const [shouldRender, setShouldRender] = useState(false);
 
   const [ref, inView] = useInView({
     threshold: 0.1,
     triggerOnce: true,
   });
+
+  // Handle authentication state changes gracefully
+  useEffect(() => {
+    if (toolsAccessible) {
+      // Small delay to prevent sudden DOM changes during Matrix modal transition
+      const timer = setTimeout(() => {
+        setShouldRender(true);
+      }, 100);
+      return () => clearTimeout(timer);
+    } else {
+      setShouldRender(false);
+    }
+  }, [toolsAccessible]);
 
   // Define available tools
   const tools = useMemo(
@@ -216,7 +230,7 @@ const ToolsSection = () => {
   }, [inView, toolsAccessible]);
 
   // Don't render anything if not unlocked
-  if (!toolsAccessible) {
+  if (!shouldRender) {
     return null;
   }
 

--- a/src/components/Tools/ToolsSection/ToolsSection.js
+++ b/src/components/Tools/ToolsSection/ToolsSection.js
@@ -7,12 +7,18 @@ import React, {
   memo,
   useEffect,
   useMemo,
+  useRef,
 } from "react";
 import { useInView } from "react-intersection-observer";
 import { useAuth } from "../../effects/Matrix/AuthContext";
 import { useKeyboardNavigation } from "../shared/hooks";
 import { FullscreenWrapper } from "./FullscreenWrapper";
 import "./styles/index.scss";
+
+// * Component timing constants
+const COMPONENT_TIMING = {
+  RENDER_DELAY_MS: 100, // Small delay to prevent abrupt DOM changes during auth transitions
+};
 
 // Enhanced loading fallback
 const LoadingFallback = memo(() => (

--- a/src/components/Tools/ToolsSection/ToolsSection.js
+++ b/src/components/Tools/ToolsSection/ToolsSection.js
@@ -190,6 +190,7 @@ const ToolsSection = () => {
       }, COMPONENT_TIMING.RENDER_DELAY_MS);
     } else {
       // Immediate hide for lock transition (no delay needed)
+      // Lock transitions are typically instant and don't cause layout issues
       setShouldRender(false);
     }
 

--- a/src/components/effects/Blur/BlurSection.js
+++ b/src/components/effects/Blur/BlurSection.js
@@ -2,6 +2,11 @@ import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import { initializeBodyScrollMotionBlur } from "./bodyScroll";
 
+// * Blur effect timing constants
+const BLUR_TIMING = {
+  INITIALIZATION_DELAY_MS: 100, // Small delay to prevent blur effect conflicts during Matrix modal transition
+};
+
 /**
  * BlurSection wraps content and applies a scroll-speed-based blur effect.
  *
@@ -31,16 +36,20 @@ const BlurSection = ({
   useEffect(() => {
     if (!disabled && containerRef.current) {
       // Small delay to prevent blur effect initialization during Matrix modal transition
+      // This prevents conflicts when authentication state changes while modal is closing
       const timer = setTimeout(() => {
-        if (cleanupRef.current) {
-          cleanupRef.current();
-          cleanupRef.current = null;
+        // Double-check that component is still mounted and not disabled
+        if (containerRef.current && !disabled) {
+          if (cleanupRef.current) {
+            cleanupRef.current();
+            cleanupRef.current = null;
+          }
+          cleanupRef.current = initializeBodyScrollMotionBlur(
+            containerRef.current,
+            { blurCap, blurAxis },
+          );
         }
-        cleanupRef.current = initializeBodyScrollMotionBlur(
-          containerRef.current,
-          { blurCap, blurAxis },
-        );
-      }, 100);
+      }, BLUR_TIMING.INITIALIZATION_DELAY_MS);
       
       return () => {
         clearTimeout(timer);
@@ -50,6 +59,8 @@ const BlurSection = ({
         }
       };
     }
+    
+    // Cleanup when disabled or component unmounts
     return () => {
       if (cleanupRef.current) {
         cleanupRef.current();

--- a/src/components/effects/Blur/BlurSection.js
+++ b/src/components/effects/Blur/BlurSection.js
@@ -30,14 +30,25 @@ const BlurSection = ({
 
   useEffect(() => {
     if (!disabled && containerRef.current) {
-      if (cleanupRef.current) {
-        cleanupRef.current();
-        cleanupRef.current = null;
-      }
-      cleanupRef.current = initializeBodyScrollMotionBlur(
-        containerRef.current,
-        { blurCap, blurAxis },
-      );
+      // Small delay to prevent blur effect initialization during Matrix modal transition
+      const timer = setTimeout(() => {
+        if (cleanupRef.current) {
+          cleanupRef.current();
+          cleanupRef.current = null;
+        }
+        cleanupRef.current = initializeBodyScrollMotionBlur(
+          containerRef.current,
+          { blurCap, blurAxis },
+        );
+      }, 100);
+      
+      return () => {
+        clearTimeout(timer);
+        if (cleanupRef.current) {
+          cleanupRef.current();
+          cleanupRef.current = null;
+        }
+      };
     }
     return () => {
       if (cleanupRef.current) {

--- a/src/components/effects/Blur/BlurSection.js
+++ b/src/components/effects/Blur/BlurSection.js
@@ -1,4 +1,4 @@
-import PropTypes from "prop-types";
+THIS SHOULD BE A LINTER ERRORimport PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import { initializeBodyScrollMotionBlur } from "./bodyScroll";
 
@@ -50,7 +50,7 @@ const BlurSection = ({
           );
         }
       }, BLUR_TIMING.INITIALIZATION_DELAY_MS);
-      
+
       return () => {
         clearTimeout(timer);
         if (cleanupRef.current) {
@@ -59,7 +59,7 @@ const BlurSection = ({
         }
       };
     }
-    
+
     // Cleanup when disabled or component unmounts
     return () => {
       if (cleanupRef.current) {

--- a/src/components/effects/Blur/BlurSection.js
+++ b/src/components/effects/Blur/BlurSection.js
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERRORimport PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import { initializeBodyScrollMotionBlur } from "./bodyScroll";
 

--- a/src/components/effects/Matrix/AuthContext.js
+++ b/src/components/effects/Matrix/AuthContext.js
@@ -190,8 +190,7 @@ export const AuthProvider = ({ children }) => {
     const inputPassword = password.toLowerCase().trim();
 
     if (inputPassword === securePassword) {
-      // * Success - set session data
-      setIsUnlocked(true);
+      // * Success - set session data immediately for persistence
       setSessionData(SESSION_KEYS.IS_UNLOCKED, true);
       setSessionData(SESSION_KEYS.SESSION_TIMESTAMP, Date.now());
 
@@ -201,6 +200,13 @@ export const AuthProvider = ({ children }) => {
 
       setShowSuccessFeedback(true);
       setTimeout(() => setShowSuccessFeedback(false), 2000);
+      
+      // * Delay the state change to prevent UI issues during Matrix modal transition
+      // This prevents sudden DOM changes and blur effect initialization conflicts
+      setTimeout(() => {
+        setIsUnlocked(true);
+      }, 2000);
+      
       return true;
     }
 

--- a/src/components/effects/Matrix/AuthContext.js
+++ b/src/components/effects/Matrix/AuthContext.js
@@ -67,6 +67,12 @@ const RATE_LIMIT_CONFIG = {
   LOCKOUT_MS: 30 * 60 * 1000, // 30 minutes
 };
 
+// * Authentication timing constants
+const AUTH_TIMING = {
+  MATRIX_MODAL_CLOSE_DELAY: 2000, // 2 seconds - matches Matrix success feedback duration
+  SUCCESS_FEEDBACK_DURATION: 2000, // 2 seconds - how long to show success message
+};
+
 const checkRateLimit = () => {
   const attemptCount = getSessionData(SESSION_KEYS.ATTEMPT_COUNT) || 0;
   const lastAttempt = getSessionData(SESSION_KEYS.LAST_ATTEMPT) || 0;
@@ -153,6 +159,7 @@ export const AuthProvider = ({ children }) => {
   const [showSuccessFeedback, setShowSuccessFeedback] = useState(false);
   const [rateLimitInfo, setRateLimitInfo] = useState(checkRateLimit());
   const audioRef = React.useRef(null);
+  const authTimeoutRef = React.useRef(null);
 
   // * Update rate limit info periodically
   useEffect(() => {
@@ -199,13 +206,15 @@ export const AuthProvider = ({ children }) => {
       clearSessionData(SESSION_KEYS.LAST_ATTEMPT);
 
       setShowSuccessFeedback(true);
-      setTimeout(() => setShowSuccessFeedback(false), 2000);
+      setTimeout(() => setShowSuccessFeedback(false), AUTH_TIMING.SUCCESS_FEEDBACK_DURATION);
       
       // * Delay the state change to prevent UI issues during Matrix modal transition
       // This prevents sudden DOM changes and blur effect initialization conflicts
-      setTimeout(() => {
+      // The delay matches the Matrix success feedback duration for smooth UX
+      authTimeoutRef.current = setTimeout(() => {
         setIsUnlocked(true);
-      }, 2000);
+        authTimeoutRef.current = null;
+      }, AUTH_TIMING.MATRIX_MODAL_CLOSE_DELAY);
       
       return true;
     }
@@ -232,11 +241,26 @@ export const AuthProvider = ({ children }) => {
 
   // * Logout function
   const logout = useCallback(() => {
+    // Clear any pending authentication timeout
+    if (authTimeoutRef.current) {
+      clearTimeout(authTimeoutRef.current);
+      authTimeoutRef.current = null;
+    }
+    
     setIsUnlocked(false);
     clearSessionData(SESSION_KEYS.IS_UNLOCKED);
     clearSessionData(SESSION_KEYS.SESSION_TIMESTAMP);
     clearSessionData(SESSION_KEYS.ATTEMPT_COUNT);
     clearSessionData(SESSION_KEYS.LAST_ATTEMPT);
+  }, []);
+
+  // * Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (authTimeoutRef.current) {
+        clearTimeout(authTimeoutRef.current);
+      }
+    };
   }, []);
 
   return (

--- a/src/components/effects/Matrix/AuthContext.js
+++ b/src/components/effects/Matrix/AuthContext.js
@@ -207,7 +207,7 @@ export const AuthProvider = ({ children }) => {
 
       setShowSuccessFeedback(true);
       setTimeout(() => setShowSuccessFeedback(false), AUTH_TIMING.SUCCESS_FEEDBACK_DURATION);
-      
+
       // * Delay the state change to prevent UI issues during Matrix modal transition
       // This prevents sudden DOM changes and blur effect initialization conflicts
       // The delay matches the Matrix success feedback duration for smooth UX
@@ -215,7 +215,7 @@ export const AuthProvider = ({ children }) => {
         setIsUnlocked(true);
         authTimeoutRef.current = null;
       }, AUTH_TIMING.MATRIX_MODAL_CLOSE_DELAY);
-      
+
       return true;
     }
 
@@ -246,7 +246,7 @@ export const AuthProvider = ({ children }) => {
       clearTimeout(authTimeoutRef.current);
       authTimeoutRef.current = null;
     }
-    
+
     setIsUnlocked(false);
     clearSessionData(SESSION_KEYS.IS_UNLOCKED);
     clearSessionData(SESSION_KEYS.SESSION_TIMESTAMP);

--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -53,8 +53,8 @@ const Matrix = ({ isVisible, onSuccess }) => {
       const success = checkPassword(password);
       if (success) {
         // Call onSuccess immediately to close the modal
-        // The authentication state change (isUnlocked) is intentionally delayed in AuthContext
-        // to prevent UI glitches during the modal transition
+        // The modal closes immediately, but the authenticated state (and thus access to protected content) 
+        // is intentionally delayed in AuthContext to avoid UI glitches during the transition
         onSuccess?.();
       }
       setPassword("");

--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERROR// Third-party imports
+// Third-party imports
 import React, { useEffect, useRef, useState, useCallback } from "react";
 
 // Context imports

--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -52,9 +52,9 @@ const Matrix = ({ isVisible, onSuccess }) => {
 
       const success = checkPassword(password);
       if (success) {
-        setTimeout(() => {
-          onSuccess?.();
-        }, 2000);
+        // Call onSuccess immediately to close the modal
+        // The authentication state change is now handled with proper timing in AuthContext
+        onSuccess?.();
       }
       setPassword("");
     },

--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -53,7 +53,8 @@ const Matrix = ({ isVisible, onSuccess }) => {
       const success = checkPassword(password);
       if (success) {
         // Call onSuccess immediately to close the modal
-        // The authentication state change is now handled with proper timing in AuthContext
+        // The authentication state change (isUnlocked) is intentionally delayed in AuthContext
+        // to prevent UI glitches during the modal transition
         onSuccess?.();
       }
       setPassword("");

--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -1,4 +1,4 @@
-// Third-party imports
+THIS SHOULD BE A LINTER ERROR// Third-party imports
 import React, { useEffect, useRef, useState, useCallback } from "react";
 
 // Context imports
@@ -158,9 +158,9 @@ const Matrix = ({ isVisible, onSuccess }) => {
   // * Update mouse trail
   useEffect(() => {
     if (!isVisible) return;
-    
+
     const interval = setInterval(() => {
-      setMouseTrail(prev => 
+      setMouseTrail(prev =>
         prev.map(point => ({ ...point, life: point.life - 1 }))
           .filter(point => point.life > 0)
       );
@@ -174,10 +174,10 @@ const Matrix = ({ isVisible, onSuccess }) => {
     const updatePerformanceMode = () => {
       setPerformanceMode(window.innerWidth < 768 ? 'mobile' : 'desktop');
     };
-    
+
     updatePerformanceMode();
     window.addEventListener('resize', updatePerformanceMode);
-    
+
     return () => window.removeEventListener('resize', updatePerformanceMode);
   }, []);
 
@@ -533,7 +533,7 @@ const Matrix = ({ isVisible, onSuccess }) => {
       lastFPSUpdate = 0;
       setCurrentFPS(0);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isVisible]);
 
   if (!isVisible) {


### PR DESCRIPTION
Synchronize authentication state changes with Matrix modal closure and add graceful component transitions to fix site breakage after login.

Previously, `isUnlocked` was set immediately upon correct password entry, but the Matrix modal remained open for 2 seconds. This caused a race condition where components like `ToolsSection` and `BlurSection` would re-render abruptly based on the new authenticated state while the modal was still visible, leading to layout shifts and site breakage. This PR delays the `isUnlocked` state change and adds small rendering delays to affected components to ensure a smooth transition.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fbc434a-e74a-44a8-beaa-d1d5865b3f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2fbc434a-e74a-44a8-beaa-d1d5865b3f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Synchronize authentication state change with Matrix modal closure and introduce delayed component rendering to prevent layout shifts and site breakage after login.

Bug Fixes:
- Fix race condition causing abrupt re-renders and layout shifts by aligning isUnlocked state change with modal closure

Enhancements:
- Delay setting isUnlocked by 2 seconds after successful password entry to match modal transition timing
- Add a short delay before initializing blur effects in BlurSection
- Add a short delay before rendering ToolsSection on authentication state change
- Invoke Matrix modal onSuccess immediately and defer state changes to AuthContext