### PR TITLE
Fix matrix container full screen height

### DIFF
--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -553,12 +553,19 @@ const Matrix = ({ isVisible, onSuccess }) => {
         position: 'fixed',
         top: 0,
         left: 0,
+        right: 0,
+        bottom: 0,
         width: '100vw',
         height: '100vh',
         margin: 0,
         padding: 0,
         border: 'none',
-        background: 'transparent'
+        background: 'transparent',
+        maxWidth: 'none',
+        maxHeight: 'none',
+        minWidth: '100vw',
+        minHeight: '100vh',
+        inset: 0
       }}
     >
       <button

--- a/src/components/effects/Matrix/matrix.scss
+++ b/src/components/effects/Matrix/matrix.scss
@@ -27,18 +27,18 @@ dialog {
   inset: auto;
 }
 
-/* Matrix Container */
-.matrix-container {
-  position: fixed !important;
-  top: 0 !important;
-  left: 0 !important;
-  right: 0 !important;
-  bottom: 0 !important;
-  width: 100vw !important;
-  height: 100vh !important;
-  margin: 0 !important;
-  padding: 0 !important;
-  border: none !important;
+/* Matrix Container - High specificity to override dialog defaults */
+dialog.matrix-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+  border: none;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -47,13 +47,11 @@ dialog {
   overflow: hidden;
   z-index: 100;
   backdrop-filter: blur(3px);
-  
-  /* Override dialog element defaults */
-  max-width: none !important;
-  max-height: none !important;
-  min-width: 100vw !important;
-  min-height: 100vh !important;
-  inset: 0 !important;
+  max-width: none;
+  max-height: none;
+  min-width: 100vw;
+  min-height: 100vh;
+  inset: 0;
   
   /* Enhanced visual effects */
   &::before {
@@ -89,6 +87,33 @@ dialog {
     visibility: hidden;
     transform: scale(0.95);
   }
+}
+
+/* Fallback for non-dialog elements */
+.matrix-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--matrix-bg);
+  transition: all var(--matrix-transition);
+  overflow: hidden;
+  z-index: 100;
+  backdrop-filter: blur(3px);
+  max-width: none;
+  max-height: none;
+  min-width: 100vw;
+  min-height: 100vh;
+  inset: 0;
 }
 
 @keyframes matrixFadeIn {
@@ -768,42 +793,26 @@ dialog {
 
 /* Ensure full screen coverage on all devices */
 @media screen {
+  dialog.matrix-container,
   .matrix-container {
-    width: 100vw !important;
-    height: 100vh !important;
-    max-width: 100vw !important;
-    max-height: 100vh !important;
-    min-width: 100vw !important;
-    min-height: 100vh !important;
-    position: fixed !important;
-    top: 0 !important;
-    left: 0 !important;
-    right: 0 !important;
-    bottom: 0 !important;
-    inset: 0 !important;
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: 100vh;
+    min-width: 100vw;
+    min-height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    inset: 0;
   }
   
   .matrix-canvas {
-    width: 100vw !important;
-    height: 100vh !important;
+    width: 100vw;
+    height: 100vh;
   }
-}
-
-/* Additional dialog-specific overrides */
-dialog.matrix-container {
-  position: fixed !important;
-  top: 0 !important;
-  left: 0 !important;
-  width: 100vw !important;
-  height: 100vh !important;
-  margin: 0 !important;
-  padding: 0 !important;
-  border: none !important;
-  max-width: none !important;
-  max-height: none !important;
-  min-width: 100vw !important;
-  min-height: 100vh !important;
-  inset: 0 !important;
 }
 
 /* Tablet Styles */
@@ -843,16 +852,17 @@ dialog.matrix-container {
 
 /* Mobile Styles */
 @media (max-width: 768px) {
+  dialog.matrix-container,
   .matrix-container {
-    width: 100vw !important;
-    height: 100vh !important;
-    max-width: 100vw !important;
-    max-height: 100vh !important;
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: 100vh;
   }
   
   .matrix-canvas {
-    width: 100vw !important;
-    height: 100vh !important;
+    width: 100vw;
+    height: 100vh;
   }
 
   .matrix-hint-bubble {

--- a/src/components/effects/Matrix/matrix.scss
+++ b/src/components/effects/Matrix/matrix.scss
@@ -10,6 +10,23 @@
   --matrix-yellow: rgba(255, 255, 0, 0.8);
 }
 
+/* Reset dialog element to ensure full screen behavior */
+dialog {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  position: static;
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: none;
+  max-height: none;
+  min-width: auto;
+  min-height: auto;
+  inset: auto;
+}
+
 /* Matrix Container */
 .matrix-container {
   position: fixed !important;
@@ -30,6 +47,13 @@
   overflow: hidden;
   z-index: 100;
   backdrop-filter: blur(3px);
+  
+  /* Override dialog element defaults */
+  max-width: none !important;
+  max-height: none !important;
+  min-width: 100vw !important;
+  min-height: 100vh !important;
+  inset: 0 !important;
   
   /* Enhanced visual effects */
   &::before {
@@ -749,12 +773,37 @@
     height: 100vh !important;
     max-width: 100vw !important;
     max-height: 100vh !important;
+    min-width: 100vw !important;
+    min-height: 100vh !important;
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    inset: 0 !important;
   }
   
   .matrix-canvas {
     width: 100vw !important;
     height: 100vh !important;
   }
+}
+
+/* Additional dialog-specific overrides */
+dialog.matrix-container {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: none !important;
+  max-width: none !important;
+  max-height: none !important;
+  min-width: 100vw !important;
+  min-height: 100vh !important;
+  inset: 0 !important;
 }
 
 /* Tablet Styles */


### PR DESCRIPTION
Ensure the `matrix-container` (a dialog element) takes up the entire screen by overriding default browser dialog styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-c72dac92-bf3f-43aa-a38b-85eba0cbd835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c72dac92-bf3f-43aa-a38b-85eba0cbd835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

