### PR TITLE
Remove tools from navbar

### DIFF
--- a/src/components/Core/constants.js
+++ b/src/components/Core/constants.js
@@ -11,5 +11,4 @@ export const NAV_ITEMS = {
   About: "/#about",
   Projects: "/#projects",
   Work: "/#work",
-  Tools: "/#tools",
 };


### PR DESCRIPTION
Remove 'Tools' navigation item from the navbar.

---
<a href="https://cursor.com/background-agent?bcId=bc-e894fccb-4d3f-4411-9d4a-b79ae8fce4f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e894fccb-4d3f-4411-9d4a-b79ae8fce4f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Chores:
- Remove 'Tools' entry from the NAV_ITEMS constants to drop it from the navbar