### PR TITLE
Repeat matrix gif on failure

### DIFF
--- a/src/components/effects/Matrix/matrix.scss
+++ b/src/components/effects/Matrix/matrix.scss
@@ -510,6 +510,16 @@ dialog.matrix-container {
 }
 
 /* Feedback Containers */
+.feedback-container-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 1000;
+}
+
 .feedback-container {
   position: absolute;
   z-index: 2;
@@ -518,6 +528,7 @@ dialog.matrix-container {
   align-items: center;
   justify-content: center;
   animation: fadeIn 0.5s ease-in-out;
+  pointer-events: auto;
 }
 
 .feedback-container img.incorrect-gif {


### PR DESCRIPTION
Duplicate the 'uh uh uh' gif display for each failed login attempt to enhance visual feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-c88a1f38-530d-4e66-873b-c013f87f0057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c88a1f38-530d-4e66-873b-c013f87f0057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Enhance failed login feedback by counting failed attempts and displaying multiple layered 'uh uh uh' GIF buttons for each failure

Enhancements:
- Track and reset the number of failed login attempts
- Render one 'incorrect password' GIF button per failed attempt with staggered positions and transforms
- Add a full-screen feedback-container-wrapper and update styles to support multiple interactive GIF containers