### PR TITLE
Animate difference overlay on load

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,9 +47,9 @@ CustomLoadingComponent.displayName = "CustomLoadingComponent";
 
 // * Layout wrapper
 const Layout = memo(
-  ({ children, navItems, onMatrixActivate, onShopActivate, isInShop }) => (
+  ({ children, navItems, onMatrixActivate, onShopActivate, isInShop, showMatrix }) => (
     <div className="app-layout">
-      <LoadingSequence />
+      <LoadingSequence showMatrix={showMatrix} />
       <div className="vignette-top" />
       <div className="vignette-bottom" />
       <div className="vignette-left" />
@@ -107,6 +107,7 @@ const MainRoutes = ({
   isShopMode,
   isUnlocked,
   isInShop,
+  showMatrix,
 }) => {
   const location = useLocation();
   const currentIsInShop = location.pathname === "/shop" || isInShop;
@@ -121,6 +122,7 @@ const MainRoutes = ({
             onMatrixActivate={onMatrixActivate}
             onShopActivate={onShopActivate}
             isInShop={currentIsInShop}
+            showMatrix={showMatrix}
           >
             {currentIsInShop ? (
               <Shop />
@@ -140,6 +142,7 @@ const MainRoutes = ({
             onMatrixActivate={onMatrixActivate}
             onShopActivate={onShopActivate}
             isInShop={true}
+            showMatrix={showMatrix}
           >
             <Shop />
           </Layout>
@@ -153,6 +156,7 @@ const MainRoutes = ({
             onMatrixActivate={onMatrixActivate}
             onShopActivate={onShopActivate}
             isInShop={currentIsInShop}
+            showMatrix={showMatrix}
           >
             <ShopBlurWrapper isShopMode={isShopMode} isUnlocked={isUnlocked}>
               <ToolsSection />
@@ -168,6 +172,7 @@ const MainRoutes = ({
             onMatrixActivate={onMatrixActivate}
             onShopActivate={onShopActivate}
             isInShop={currentIsInShop}
+            showMatrix={showMatrix}
           >
             <ShopBlurWrapper isShopMode={isShopMode} isUnlocked={isUnlocked}>
               <ToolsSection />
@@ -270,6 +275,7 @@ const AppContent = () => {
             isShopMode={isShopMode}
             isUnlocked={isUnlocked}
             isInShop={isInShop}
+            showMatrix={showMatrix}
           />
         </Suspense>
       </BrowserRouter>

--- a/src/components/effects/Loading/LoadingSequence.js
+++ b/src/components/effects/Loading/LoadingSequence.js
@@ -1,5 +1,5 @@
 // LoadingSequence.js
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 const MaskCommon = styled.div`
@@ -11,6 +11,7 @@ const MaskCommon = styled.div`
 	z-index: 20000;
 	transition: transform 1s ease-in-out;
 	mix-blend-mode: difference;
+	display: ${props => props.isVisible ? 'block' : 'none'};
 `;
 
 const MaskTop = styled(MaskCommon)`
@@ -23,8 +24,14 @@ const MaskBottom = styled(MaskCommon)`
 	transform-origin: bottom;
 `;
 
-const LoadingSequence = ({ onComplete }) => {
+const LoadingSequence = ({ onComplete, showMatrix = false }) => {
+  const [isVisible, setIsVisible] = useState(true);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  // Initial load animation
   useEffect(() => {
+    if (isAnimating) return;
+
     const maskTop = document.getElementById("MaskTop");
     const maskBottom = document.getElementById("MaskBottom");
     const magicContainer = document.getElementById("magicContainer");
@@ -69,12 +76,65 @@ const LoadingSequence = ({ onComplete }) => {
         maskBottom.style.display = "";
       }
     };
-  }, [onComplete]);
+  }, [onComplete, isAnimating]);
+
+  // Matrix activation animation
+  useEffect(() => {
+    if (!showMatrix) return;
+
+    setIsAnimating(true);
+    setIsVisible(true);
+
+    const maskTop = document.getElementById("MaskTop");
+    const maskBottom = document.getElementById("MaskBottom");
+    const magicContainer = document.getElementById("magicContainer");
+
+    // Reset masks to full screen
+    if (maskTop) {
+      maskTop.style.display = "block";
+      maskTop.style.transform = "scaleY(1)";
+    }
+    if (maskBottom) {
+      maskBottom.style.display = "block";
+      maskBottom.style.transform = "scaleY(1)";
+    }
+
+    // Hide magic container
+    if (magicContainer) {
+      magicContainer.style.opacity = "0";
+    }
+
+    // Close animation
+    const t1 = setTimeout(() => {
+      if (maskTop) maskTop.style.transform = "scaleY(0)";
+      if (maskBottom) maskBottom.style.transform = "scaleY(0)";
+    }, 100);
+
+    // Fade in magic container
+    const t2 = setTimeout(() => {
+      if (magicContainer) {
+        magicContainer.style.opacity = "0.2";
+      }
+    }, 300);
+
+    // Clean up
+    const t3 = setTimeout(() => {
+      if (maskTop) maskTop.style.display = "none";
+      if (maskBottom) maskBottom.style.display = "none";
+      setIsAnimating(false);
+    }, 1500);
+
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [showMatrix]);
 
   return (
     <>
-      <MaskTop id="MaskTop" />
-      <MaskBottom id="MaskBottom" />
+      <MaskTop id="MaskTop" isVisible={isVisible} />
+      <MaskBottom id="MaskBottom" isVisible={isVisible} />
     </>
   );
 };


### PR DESCRIPTION
Re-trigger the difference overlay animation when the Matrix effect is activated.

This change allows the initial loading sequence's difference overlay animation to play again (close and then reopen) when the Matrix effect is activated, providing a dramatic visual transition that matches the website's initial load.

---
<a href="https://cursor.com/background-agent?bcId=bc-589c70c7-c3a1-4773-879e-f3bbd927a2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-589c70c7-c3a1-4773-879e-f3bbd927a2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Replay the loading difference overlay animation when the Matrix effect is triggered to match the site's initial dramatic transition

New Features:
- Re-trigger the difference overlay animation on Matrix effect activation

Enhancements:
- Add showMatrix prop and internal animation state to LoadingSequence
- Propagate showMatrix flag through Layout and routing components to LoadingSequence