### PR TITLE
Reverse opening animation for matrix

### DIFF
--- a/src/components/effects/Loading/LoadingSequence.js
+++ b/src/components/effects/Loading/LoadingSequence.js
@@ -89,14 +89,14 @@ const LoadingSequence = ({ onComplete, showMatrix = false }) => {
     const maskBottom = document.getElementById("MaskBottom");
     const magicContainer = document.getElementById("magicContainer");
 
-    // Reset masks to full screen
+    // Start with masks closed (already open from initial load)
     if (maskTop) {
       maskTop.style.display = "block";
-      maskTop.style.transform = "scaleY(1)";
+      maskTop.style.transform = "scaleY(0)";
     }
     if (maskBottom) {
       maskBottom.style.display = "block";
-      maskBottom.style.transform = "scaleY(1)";
+      maskBottom.style.transform = "scaleY(0)";
     }
 
     // Hide magic container
@@ -104,16 +104,16 @@ const LoadingSequence = ({ onComplete, showMatrix = false }) => {
       magicContainer.style.opacity = "0";
     }
 
-    // Close animation
+    // Open animation (reverse of initial load)
     const t1 = setTimeout(() => {
-      if (maskTop) maskTop.style.transform = "scaleY(0)";
-      if (maskBottom) maskBottom.style.transform = "scaleY(0)";
+      if (maskTop) maskTop.style.transform = "scaleY(1)";
+      if (maskBottom) maskBottom.style.transform = "scaleY(1)";
     }, 100);
 
-    // Fade in magic container
+    // Keep magic container hidden during matrix
     const t2 = setTimeout(() => {
       if (magicContainer) {
-        magicContainer.style.opacity = "0.2";
+        magicContainer.style.opacity = "0";
       }
     }, 300);
 


### PR DESCRIPTION
Reverse the `LoadingSequence` opening effect animation when the Matrix is activated.

This ensures that when the Matrix is started, the masks close over the screen rather than opening, providing the intended visual transition.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d32deed-ac1c-4cd6-b075-378de1345e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d32deed-ac1c-4cd6-b075-378de1345e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Reverse the LoadingSequence opening animation to close masks over the screen when the Matrix activates and keep the magic container hidden during the transition

Enhancements:
- Invert mask transforms to start closed and animate to open over the screen instead of the original opening effect
- Maintain the magic container fully hidden by setting its opacity to 0 throughout the Matrix transition