### PR TITLE
Layer closing effect behind auth login

### DIFF
--- a/src/components/effects/Loading/LoadingSequence.js
+++ b/src/components/effects/Loading/LoadingSequence.js
@@ -8,7 +8,7 @@ const MaskCommon = styled.div`
 	width: 100%;
 	height: 50%;
 	background: #999;
-	z-index: 20000;
+	z-index: 500; /* Lower than Matrix modal z-index values (2000s) */
 	transition: transform 1s ease-in-out;
 	mix-blend-mode: difference;
 	display: ${props => props.isVisible ? 'block' : 'none'};


### PR DESCRIPTION
Update `LoadingSequence` z-index to ensure the difference effect appears behind the Matrix modal's auth context elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5131bf9-5232-4084-9329-705b04d0a97b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5131bf9-5232-4084-9329-705b04d0a97b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Bug Fixes:
- Reduce MaskCommon z-index from 20000 to 500 to layer the closing effect behind the auth login modal