### PR TITLE
Ensure gif is on top of all layers

### DIFF
--- a/src/components/effects/Matrix/matrix.scss
+++ b/src/components/effects/Matrix/matrix.scss
@@ -546,12 +546,12 @@ dialog.matrix-container {
   width: 100vw;
   height: 100vh;
   pointer-events: none;
-  z-index: var(--z-background);
+  z-index: var(--z-notification);
 }
 
 .feedback-container {
   position: absolute;
-  z-index: var(--z-feedback);
+  z-index: var(--z-notification);
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
Update z-index for feedback and matrix containers to ensure the "nu-uh-uh" gif is always visible.

The "nu-uh-uh" gif was hidden behind the matrix rain effect because the canvas had a higher z-index (`--z-canvas: 1001`) than the feedback container wrapper (`--z-background: 1000`). By setting both the `.matrix-container` and `.feedback-container` to use `--z-notification` (3001), the gif will now appear on top of all layers.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ee7f86a-b765-4406-8c44-3ebe5705b020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ee7f86a-b765-4406-8c44-3ebe5705b020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Bug Fixes:
- Set .matrix-container and .feedback-container z-index to --z-notification to prevent the gif from being hidden behind the matrix effect