### PR TITLE
Fix blue sky logo color in header

### DIFF
--- a/src/components/content/Header/header.scss
+++ b/src/components/content/Header/header.scss
@@ -227,10 +227,10 @@ $header-tokens: (
         height: 2.5em;
         color: inherit;
         transition: color 0.5s;
-        filter: brightness(0) saturate(100%) invert(100%);
+        filter: none;
 
         &:hover {
-          filter: brightness(0) saturate(100%) invert(100%) sepia(100%) saturate(2000%) hue-rotate(200deg);
+          filter: none;
         }
       }
     }


### PR DESCRIPTION
Remove CSS color filters from the `.custom-icon` class to allow the Blue Sky logo to display its intended color.

The previous filters were incorrectly forcing the Blue Sky logo to white, causing an inconsistency with other social media icons in the header.

---
<a href="https://cursor.com/background-agent?bcId=bc-124a50a2-a130-4a58-aae5-c467972a58b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-124a50a2-a130-4a58-aae5-c467972a58b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Bug Fixes:
- Allow the Blue Sky logo to display its intended color by removing forced white filters on .custom-icon