### PR TITLE
Remove spiral reveal loading option

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -166,7 +166,7 @@ const AppContent = () => {
   const { isUnlocked } = useAuth();
   const [isShopMode, setIsShopMode] = useState(false);
   const [isInShop, setIsInShop] = useState(false);
-  const [loadingVariant, setLoadingVariant] = useState(1); // Default to variant 1
+  const [loadingVariant, setLoadingVariant] = useState(2); // Default to variant 2 (Particle Burst)
   const scrollAnimationRef = useRef();
   const shopScrollSpeedRef = useRef(400);
 

--- a/src/components/effects/Loading/LoadingSequenceVariants.js
+++ b/src/components/effects/Loading/LoadingSequenceVariants.js
@@ -4,21 +4,6 @@ import styled, { keyframes } from "styled-components";
 
 // ===== ANIMATION KEYFRAMES =====
 
-// Spiral reveal animation
-const spiralReveal = keyframes`
-  0% { 
-    transform: scale(0) rotate(0deg);
-    opacity: 1;
-  }
-  50% {
-    transform: scale(1.1) rotate(180deg);
-    opacity: 0.8;
-  }
-  100% { 
-    transform: scale(1) rotate(360deg);
-    opacity: 0;
-  }
-`;
 
 // Particle burst animation
 const particleBurst = keyframes`
@@ -111,16 +96,6 @@ const LoadingOverlay = styled.div`
   flex-direction: column;
 `;
 
-// Variant 1: Spiral Reveal
-const SpiralLoader = styled.div`
-  width: 100px;
-  height: 100px;
-  border: 3px solid transparent;
-  border-top: 3px solid #00ff88;
-  border-right: 3px solid #0088ff;
-  border-radius: 50%;
-  animation: ${spiralReveal} 2s ease-in-out forwards;
-`;
 
 // Variant 2: Particle Burst
 const ParticleContainer = styled.div`
@@ -224,24 +199,6 @@ const GlitchContainer = styled.div`
 
 // ===== LOADING SEQUENCE VARIANTS =====
 
-export const LoadingSequenceVariant1 = ({ onComplete }) => {
-  const [isVisible, setIsVisible] = useState(true);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsVisible(false);
-      if (onComplete) onComplete();
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, [onComplete]);
-
-  return (
-    <LoadingOverlay isVisible={isVisible}>
-      <SpiralLoader />
-    </LoadingOverlay>
-  );
-};
 
 export const LoadingSequenceVariant2 = ({ onComplete }) => {
   const [isVisible, setIsVisible] = useState(true);
@@ -440,13 +397,12 @@ const LoadingSequence = ({ onComplete, variant = 1, showMatrix = false, onMatrix
     const commonProps = { onComplete: () => setIsVisible(false) };
 
     switch (variant) {
-      case 1: return <LoadingSequenceVariant1 {...commonProps} />;
       case 2: return <LoadingSequenceVariant2 {...commonProps} />;
       case 3: return <LoadingSequenceVariant3 {...commonProps} />;
       case 4: return <LoadingSequenceVariant4 {...commonProps} />;
       case 5: return <LoadingSequenceVariant5 {...commonProps} />;
       case 6: return <LoadingSequenceVariant6 {...commonProps} />;
-      default: return <LoadingSequenceVariant1 {...commonProps} />;
+      default: return <LoadingSequenceVariant2 {...commonProps} />;
     }
   };
 

--- a/src/components/effects/Loading/LoadingVariantSelector.js
+++ b/src/components/effects/Loading/LoadingVariantSelector.js
@@ -37,7 +37,6 @@ const Select = styled.select`
 
 const LoadingVariantSelector = ({ variant, onVariantChange }) => {
   const variants = [
-    { value: 1, label: 'Spiral Reveal' },
     { value: 2, label: 'Particle Burst' },
     { value: 3, label: 'Wave Ripple' },
     { value: 4, label: 'Typewriter' },


### PR DESCRIPTION
Remove the "Spiral Reveal" loading style option as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b24a13c-ffe6-4596-bdf4-0f1e10f30cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b24a13c-ffe6-4596-bdf4-0f1e10f30cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

