### PR TITLE
Keep password visible in matrix mode

### DIFF
--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -429,7 +429,7 @@ const Matrix = ({ isVisible, onSuccess }) => {
         failedAttempts={failedAttempts}
       />
 
-      {!showSuccessFeedback && !showIncorrectFeedback && (
+      {!showSuccessFeedback && (
         <form ref={formRef} onSubmit={handleSubmit} className="password-form">
           <input
             type="password"


### PR DESCRIPTION
### **User description**
Keep the password input visible during incorrect feedback in Matrix mode.

The password form was previously hidden when `showIncorrectFeedback` was true, preventing users from seeing their input or attempting to re-enter a password immediately. This change allows users to retry without waiting for the feedback to disappear.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0771971-72e4-42eb-80f4-4703f10a80d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0771971-72e4-42eb-80f4-4703f10a80d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Bug fix


___

### **Description**
- Remove condition hiding password form during incorrect feedback

- Allow users to retry password immediately in Matrix mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Password Form"] --> B["Incorrect Feedback"]
  B --> C["Form Hidden (Before)"]
  B --> D["Form Visible (After)"]
  D --> E["User Can Retry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Matrix.js</strong><dd><code>Remove incorrect feedback condition from form visibility</code>&nbsp; </dd></summary>
<hr>

src/components/effects/Matrix/Matrix.js

<ul><li>Removed <code>!showIncorrectFeedback</code> condition from password form visibility<br> <li> Form now remains visible when incorrect feedback is shown<br> <li> Users can immediately retry password entry without waiting</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/Personal-Website/pull/200/files#diff-4d3a1bd202938ec8ed21d424beb0e343c95ba006f10254a3dcd84db11b7c3a67">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

