### PR TITLE
Set cat as background

### DIFF
--- a/CAT_BACKGROUND_INSTRUCTIONS.md
+++ b/CAT_BACKGROUND_INSTRUCTIONS.md
@@ -1,0 +1,33 @@
+# Cat Background Setup Instructions
+
+## Current Implementation
+Your website now has a cat background! I've added a placeholder SVG cat image that works with both light and dark themes.
+
+## To Replace with Your Actual Cat Photo
+
+1. **Add your cat image** to `/workspace/src/assets/images/`
+   - Name it `cat-background.jpg` (or `.png`, `.webp`)
+   - Recommended size: 1920x1080 or larger
+   - Format: JPG, PNG, or WebP
+
+2. **Update the CSS** in `/workspace/src/sass/_base.scss`
+   - Find line 159: `background: var(--background-color) url("../assets/images/cat-background.svg") no-repeat center center fixed;`
+   - Change `cat-background.svg` to `cat-background.jpg` (or your file extension)
+
+3. **Rebuild the project**
+   ```bash
+   npm run build
+   ```
+
+## Current Features
+- ✅ Cat background image (placeholder SVG)
+- ✅ Works with both light and dark themes
+- ✅ Semi-transparent overlay for text readability
+- ✅ Responsive design
+- ✅ Fixed background (doesn't scroll with content)
+
+## Theme Support
+- **Dark theme**: Dark overlay (30% opacity) for better text contrast
+- **Light theme**: Light overlay (70% opacity) for better text contrast
+
+The background will automatically adjust its overlay based on the current theme!

--- a/src/assets/images/cat-background.svg
+++ b/src/assets/images/cat-background.svg
@@ -1,0 +1,39 @@
+<svg viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="100%" height="100%" fill="#1a1a1d"/>
+  
+  <!-- Cat silhouette -->
+  <g fill="#d8e3e7" opacity="0.1">
+    <!-- Cat head -->
+    <ellipse cx="600" cy="300" rx="120" ry="100"/>
+    
+    <!-- Cat ears -->
+    <polygon points="520,220 480,180 520,200"/>
+    <polygon points="680,220 720,180 680,200"/>
+    
+    <!-- Cat body -->
+    <ellipse cx="600" cy="450" rx="150" ry="200"/>
+    
+    <!-- Cat tail -->
+    <path d="M750,450 Q850,400 900,500 Q850,600 750,550" stroke="#d8e3e7" stroke-width="8" fill="none" opacity="0.1"/>
+    
+    <!-- Cat paws -->
+    <ellipse cx="500" cy="620" rx="30" ry="40"/>
+    <ellipse cx="700" cy="620" rx="30" ry="40"/>
+    
+    <!-- Cat eyes -->
+    <circle cx="570" cy="280" r="8" fill="#d8e3e7" opacity="0.2"/>
+    <circle cx="630" cy="280" r="8" fill="#d8e3e7" opacity="0.2"/>
+    
+    <!-- Cat nose -->
+    <polygon points="600,300 590,320 610,320" fill="#d8e3e7" opacity="0.2"/>
+  </g>
+  
+  <!-- Subtle pattern overlay -->
+  <defs>
+    <pattern id="catPattern" x="0" y="0" width="100" height="100" patternUnits="userSpaceOnUse">
+      <circle cx="50" cy="50" r="1" fill="#d8e3e7" opacity="0.03"/>
+    </pattern>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#catPattern)"/>
+</svg>

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -156,7 +156,8 @@ body {
     font-weight: 400;
     font-size: 1.4rem;
     line-height: 1.6;
-    background: var(--background-color);
+    background: var(--background-color) url("../assets/images/cat-background.svg") no-repeat center center fixed;
+    background-size: cover;
     color: var(--text-color);
     transition:
       background-color var(--theme-transition-duration) var(--theme-transition-timing),
@@ -166,6 +167,20 @@ body {
     position: relative;
     min-height: 100vh;
     overflow-x: hidden;
+  }
+
+  // * Cat background overlay for better text readability
+  &::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--cat-overlay);
+    pointer-events: none;
+    z-index: -1;
+    transition: background var(--theme-transition-duration) var(--theme-transition-timing);
   }
 
   * {
@@ -204,6 +219,13 @@ body {
         $theme-name == "light",
         "0 2px 10px rgba(255, 255, 255, 0.4)",
         "2px 2px 10px rgba(var(--shadow-color), var(--shadow-opacity))"
+      )};
+    
+    // * Cat background overlay for better text readability
+    --cat-overlay: #{if(
+        $theme-name == "light",
+        "rgba(255, 255, 255, 0.7)",
+        "rgba(0, 0, 0, 0.3)"
       )};
   }
 


### PR DESCRIPTION
Add a placeholder cat background image with a theme-aware overlay for improved text readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-74481323-937e-4d5f-ae13-73281ae5ed73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74481323-937e-4d5f-ae13-73281ae5ed73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Set a placeholder cat image as the site background with a theme-aware overlay for better readability and provide customization instructions

New Features:
- Add placeholder cat background image with fixed cover styling for the site body

Enhancements:
- Introduce theme-aware semi-transparent overlay via ::before for improved text readability

Documentation:
- Add CAT_BACKGROUND_INSTRUCTIONS.md with instructions for replacing the placeholder background image