### PR TITLE
Add test coverage for color utilities

### DIFF
--- a/src/utils/__tests__/colorUtils.test.js
+++ b/src/utils/__tests__/colorUtils.test.js
@@ -1,0 +1,82 @@
+import {
+  DEFAULT_BASE_COLORS,
+  generateItemColors,
+  generateTagColors,
+} from "../colorUtils";
+
+const getDefaultHslOrder = () =>
+  Object.values(DEFAULT_BASE_COLORS).map(
+    ({ h, s, l }) => `hsl(${h}, ${s}%, ${l}%)`,
+  );
+
+describe("colorUtils", () => {
+  describe("generateTagColors", () => {
+    it("cycles through the default palette when keywords exceed available colors", () => {
+      const keywords = [
+        "alpha",
+        "beta",
+        "gamma",
+        "delta",
+        "epsilon",
+        "zeta",
+        "eta",
+        "theta",
+      ];
+
+      const result = generateTagColors(keywords);
+      const defaultHsl = getDefaultHslOrder();
+
+      keywords.forEach((keyword, index) => {
+        const expectedColor = defaultHsl[index % defaultHsl.length];
+        expect(result[keyword]).toBe(expectedColor);
+      });
+    });
+
+    it("uses custom base colors when provided", () => {
+      const customBaseColors = {
+        first: { h: 10, s: 20, l: 30 },
+        second: { h: 40, s: 50, l: 60 },
+      };
+
+      const keywords = ["one", "two"];
+
+      const result = generateTagColors(keywords, customBaseColors);
+
+      expect(result).toEqual({
+        one: "hsl(10, 20%, 30%)",
+        two: "hsl(40, 50%, 60%)",
+      });
+    });
+
+    it("overwrites duplicate keywords with the latest assigned color", () => {
+      const keywords = ["alpha", "beta", "alpha", "gamma", "beta"];
+
+      const result = generateTagColors(keywords);
+      const defaultHsl = getDefaultHslOrder();
+
+      expect(result).toEqual({
+        alpha: defaultHsl[2],
+        beta: defaultHsl[4],
+        gamma: defaultHsl[3],
+      });
+    });
+  });
+
+  describe("generateItemColors", () => {
+    it("uses a custom key property to derive unique item keys", () => {
+      const items = [
+        { slug: "first", label: "Item One" },
+        { slug: "second", label: "Item Two" },
+        { slug: "first", label: "Item One Duplicate" },
+      ];
+
+      const result = generateItemColors(items, "slug");
+      const defaultHsl = getDefaultHslOrder();
+
+      expect(result).toEqual({
+        first: defaultHsl[0],
+        second: defaultHsl[1],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary
- add unit tests for generateTagColors covering default palette cycling, custom base colors, and duplicates
- add generateItemColors test to verify custom key property support

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68f2bb0aa8648333b46311725700d8f5


___

## **CodeAnt-AI Description**
**Add unit tests for tag and item color assignment**

### What Changed
- Tests verify tag colors cycle through the default palette when there are more keywords than base colors
- Tests verify custom base colors produce the expected HSL strings for each keyword
- Tests verify duplicate keywords are resolved so the last occurrence determines the final tag color
- Tests verify item colors are assigned using a provided key property and duplicate items share a single color

### Impact
 `✅ Fewer color regressions`
 `✅ Predictable tag color assignment`
 `✅ Consistent item color mapping when items share keys`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
