### PR TITLE
Fix chat bubble keyboard handler

### DIFF
--- a/src/components/content/Header/Header.js
+++ b/src/components/content/Header/Header.js
@@ -87,7 +87,7 @@ const ChatBubble = ({ isVisible }) => {
     <div
       className={`chat-bubble ${isVisible ? "visible" : ""} ${hintLevel > 0 ? `level-${hintLevel}` : ""}`}
       onClick={handleClick}
-      onKeyUp={(e) => e.key === "Enter" && handleClick()}
+      onKeyUp={(e) => e.key === "Enter" && handleClick(e)}
     >
       {["a", "b", "c"].map((part) => (
         <ChatBubblePart key={part} part={part} />

--- a/src/components/content/Header/Header.test.js
+++ b/src/components/content/Header/Header.test.js
@@ -1,0 +1,19 @@
+import { fireEvent, render } from "@testing-library/react";
+
+jest.mock("./useScrambleEffect", () => jest.fn());
+
+import Header from "./Header";
+
+describe("ChatBubble accessibility", () => {
+  it("does not throw when activated via keyboard", () => {
+    const { container } = render(<Header />);
+    const chatBubble = container.querySelector(".chat-bubble");
+
+    expect(chatBubble).not.toBeNull();
+
+    // Ensure no errors occur when triggering the keyboard interaction.
+    expect(() => {
+      fireEvent.keyUp(chatBubble, { key: "Enter" });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary
- pass the keyboard event to the chat bubble click handler to prevent propagation errors
- add a regression test that ensures keyboard activation of the chat bubble does not throw

## Testing
- CI=true npm test -- Header.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f2ba1c91a08333848828c54e31cc51


___

## **CodeAnt-AI Description**
**Prevent error when activating chat bubble with Enter**

### What Changed
- Pressing Enter while focused on the header chat bubble no longer throws an error; keyboard activation now invokes the same behavior as clicking.
- The Enter key event is passed into the chat-bubble handler so the handler can stop propagation without failing.
- Added a regression test that renders the header and confirms triggering Enter on the chat bubble does not throw, guarding against future regressions.

### Impact
`✅ Keyboard activation of chat bubble works without throwing`
`✅ Fewer runtime errors during keyboard navigation in header`
`✅ Regression test prevents reintroduction of this keyboard bug`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
