### PR TITLE
Handle missing DOM placeholders and guard analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,9 @@ REACT_APP_PRINTFUL_STORE_ID=your_store_id_here
 
 # Development Configuration
 SKIP_PREFLIGHT_CHECK=true
+
+# Analytics
+# Set to "true" to enable the optional Vercel Analytics script in production builds.
+# Leaving this unset (or any value other than "true") keeps the script disabled to
+# avoid console warnings in environments without Web Analytics support.
+REACT_APP_ENABLE_VERCEL_ANALYTICS=false

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ In the future, I plan to continue updating the blog and publications sections wi
 - The same command also converts JPEG/PNG files to `.avif` using `imagemin-avif` (requires Node.js 18 or later).
 - A pre-commit hook runs this command automatically.
 - Consider using Git LFS for large image files.
+- Optional [Vercel Analytics](https://vercel.com/docs/analytics/quickstart) support is gated behind the `REACT_APP_ENABLE_VERCEL_ANALYTICS` environment variable. Set it to `true` when your deployment has Web Analytics enabled.
 
 ## Project Structure
 

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,20 @@
     </script>
   </head>
   <body>
+    <!--
+      Hidden placeholders for third-party scripts that expect localized error and consent
+      message containers to exist in the DOM. Without these elements the scripts emit
+      noisy console errors when they attempt to populate the messages. We keep the
+      containers hidden to avoid impacting the UI while still satisfying the lookup.
+    -->
+    <div id="i18n-placeholders" aria-hidden="true" hidden>
+      <div id="i18n_error_msg_default">An unexpected error occurred. Please try again later.</div>
+      <div id="i18n_conflict_error">This content is temporarily unavailable due to a conflict. Please refresh the page.</div>
+      <div id="gdpr_notice">
+        We use anonymized analytics to understand how the site is used. By continuing to browse you agree to this use.
+      </div>
+      <div id="gdprLearnMoreLabel">Learn more about our analytics policy.</div>
+    </div>
     <noscript>
       <style>
         .noscript-container {

--- a/src/App.js
+++ b/src/App.js
@@ -47,6 +47,14 @@ const CustomLoadingComponent = () => (
 );
 CustomLoadingComponent.displayName = "CustomLoadingComponent";
 
+const AnalyticsWrapper = memo(() => {
+  if (process.env.REACT_APP_ENABLE_VERCEL_ANALYTICS !== "true") {
+    return null;
+  }
+  return <Analytics />;
+});
+AnalyticsWrapper.displayName = "AnalyticsWrapper";
+
 // * Layout wrapper
 const Layout = memo(
   ({ children, navItems, onMatrixActivate, onScrollActivate, isInScroll, showMatrix, onMatrixReady, isUnlocked, hideNavBar }) => (
@@ -270,7 +278,7 @@ const App = () => (
   <GoogleSheetsProvider config={GOOGLE_SHEETS_CONFIG}>
     <AuthProvider>
       <AppContent />
-      <Analytics />
+      <AnalyticsWrapper />
     </AuthProvider>
   </GoogleSheetsProvider>
 );


### PR DESCRIPTION
## Summary
- add hidden localized/gdpr placeholders to the base HTML so third-party scripts no longer throw missing element errors
- wrap the Vercel analytics component so it only renders when explicitly enabled

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f2efbbb0e083339e70ec6296e4d920