### PR TITLE
Adjust tablet breakpoint to trigger small layout at 1016px

### DIFF
--- a/src/components/effects/Matrix/constants.js
+++ b/src/components/effects/Matrix/constants.js
@@ -98,7 +98,7 @@ export const TYPOGRAPHY = {
 export const LAYOUT = {
   // Breakpoints (should match CSS media queries)
   MOBILE_BREAKPOINT: 768,
-  TABLET_BREAKPOINT: 1024,
+  TABLET_BREAKPOINT: 1016,
   DESKTOP_BREAKPOINT: 1200,
 
   // Spacing

--- a/src/hooks/useMobileDetection.js
+++ b/src/hooks/useMobileDetection.js
@@ -14,8 +14,8 @@ export const useMobileDetection = () => {
   // Define breakpoints (matching the SCSS breakpoints)
   const breakpoints = {
     mobile: 768,    // Below 768px is considered mobile
-    tablet: 1024,   // 768px - 1024px is tablet
-    desktop: 1025   // Above 1024px is desktop
+    tablet: 1016,   // 768px - 1016px is tablet
+    desktop: 1017   // Above 1016px is desktop
   };
 
   const updateScreenSize = useCallback(() => {

--- a/src/sass/_enhanced-accessibility.scss
+++ b/src/sass/_enhanced-accessibility.scss
@@ -244,7 +244,7 @@
       }
     }
   } @else if $breakpoint == 'md' {
-    @media (min-width: 768px) and (max-width: 1023px) {
+    @media (min-width: 768px) and (max-width: 1015px) {
       @if $behavior == 'stack' {
         flex-direction: row;
         gap: map.get(tokens.$enhanced-spacing-scale, '5');
@@ -257,7 +257,7 @@
       }
     }
   } @else if $breakpoint == 'lg' {
-    @media (min-width: 1024px) and (max-width: 1439px) {
+    @media (min-width: 1016px) and (max-width: 1439px) {
       @if $behavior == 'stack' {
         flex-direction: row;
         gap: map.get(tokens.$enhanced-spacing-scale, '6');

--- a/src/sass/_enhanced-typography.scss
+++ b/src/sass/_enhanced-typography.scss
@@ -166,7 +166,7 @@
   }
   
   // Desktop and up
-  @media (min-width: 1024px) {
+  @media (min-width: 1016px) {
     @if $style == 'body' or $style == 'body-small' {
       font-size: enhanced-type('lg');
     } @else if $style == 'body-large' {


### PR DESCRIPTION
## **User description**
## Summary
- adjust responsive SCSS breakpoints so desktop-specific styles start at 1016px
- align JavaScript breakpoint constants with the new threshold

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3001189e083338b98c2dc2e7d30b9


___

## **CodeAnt-AI Description**
**Switch to desktop layout and larger typography starting at 1016px**

### What Changed
- The breakpoint where the UI switches from tablet to desktop has moved from 1024px down to 1016px, so desktop layouts and spacing apply earlier on narrower screens.
- Grid and layout behaviors now switch to wider (desktop) arrangements at 1016px (e.g., two-column to three-column grids and larger gaps happen sooner).
- Typography scales up to desktop sizes at 1016px, so body and large text become the desktop sizes slightly earlier.
- JavaScript breakpoint values and the app's mobile/tablet/desktop detection were updated to match the new CSS breakpoints, reducing mismatch between visual styles and feature behaviors.
- Effects and components that rely on the Matrix layout constants or on-screen-size detection will now treat screens >1016px as desktop, altering their responsive behavior in that range.

### Impact
`✅ Fewer layout shifts when resizing between tablet and desktop`
`✅ Consistent typography scaling at 1016px breakpoint`
`✅ Aligned JS/CSS breakpoints so responsive features behave consistently`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
