### PR TITLE
Silence npm config warnings during lint

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,12 @@
+; Shared npm configuration
 legacy-peer-deps=true
-strict-peer-dependencies=false
-auto-install-peers=true
-resolution-mode=highest
 save-exact=false
 install-links=true
+loglevel=error
+
+; The following pnpm-specific flags used to live here, but npm prints warnings
+; for unknown keys. If you still rely on pnpm, configure these options in a
+; local ~/.npmrc or pnpm-workspace file instead:
+;   strict-peer-dependencies=false
+;   auto-install-peers=true
+;   resolution-mode=highest

--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -668,54 +668,52 @@ const Matrix = ({ isVisible, onSuccess }) => {
             </ul>
           </div>
         </section>
-        <div className="matrix-console-shell__stack">
-          <div
-            className={`hack-sequencer ${isHackingComplete ? "complete" : ""}`}
-            aria-live="polite"
-          >
-            <div className="hack-sequencer__header">
-              <span className="hack-sequencer__spacer" aria-hidden="true">
-                {Math.round(hackProgress)}%
-              </span>
-              <span className="hack-sequencer__title">
-                {isHackingComplete ? "Access channel secured" : "Hack into mainframe"}
-              </span>
-              <span className="hack-sequencer__percentage">
-                {Math.round(hackProgress)}%
-              </span>
-            </div>
-            <div className="hack-sequencer__bar">
-              <div
-                className="hack-sequencer__fill"
-                style={{ width: `${hackProgress}%` }}
-              />
-            </div>
-            <p className="hack-sequencer__feedback">{hackFeedback}</p>
+        <div
+          className={`hack-sequencer ${isHackingComplete ? "complete" : ""}`}
+          aria-live="polite"
+        >
+          <div className="hack-sequencer__header">
+            <span className="hack-sequencer__spacer" aria-hidden="true">
+              {Math.round(hackProgress)}%
+            </span>
+            <span className="hack-sequencer__title">
+              {isHackingComplete ? "Access channel secured" : "Hack into mainframe"}
+            </span>
+            <span className="hack-sequencer__percentage">
+              {Math.round(hackProgress)}%
+            </span>
           </div>
-
-          {!showSuccessFeedback && (
+          <div className="hack-sequencer__bar">
             <div
-              className={`hack-input-panel ${isHackingComplete ? "complete" : ""}`}
-            >
-              <input
-                type="text"
-                value={hackingBuffer}
-                onChange={handleHackInputChange}
-                ref={hackInputRef}
-                onKeyDown={handleHackKeyDown}
-                placeholder="Mash the keys to amplify the breach"
-                className="hack-input-field"
-                disabled={isHackingComplete}
-                aria-label="Hack input stream"
-              />
-              <div className="hack-input-helper" aria-hidden="true">
-                {isHackingComplete
-                  ? "Channel stabilized"
-                  : "Keep mashing to stabilize the signal"}
-              </div>
-            </div>
-          )}
+              className="hack-sequencer__fill"
+              style={{ width: `${hackProgress}%` }}
+            />
+          </div>
+          <p className="hack-sequencer__feedback">{hackFeedback}</p>
         </div>
+
+        {!showSuccessFeedback && (
+          <div
+            className={`hack-input-panel ${isHackingComplete ? "complete" : ""}`}
+          >
+            <input
+              type="text"
+              value={hackingBuffer}
+              onChange={handleHackInputChange}
+              ref={hackInputRef}
+              onKeyDown={handleHackKeyDown}
+              placeholder="Mash the keys to amplify the breach"
+              className="hack-input-field"
+              disabled={isHackingComplete}
+              aria-label="Hack input stream"
+            />
+            <div className="hack-input-helper" aria-hidden="true">
+              {isHackingComplete
+                ? "Channel stabilized"
+                : "Keep mashing to stabilize the signal"}
+            </div>
+          </div>
+        )}
       </div>
       <button
         type="button"

--- a/src/components/effects/Matrix/matrix.scss
+++ b/src/components/effects/Matrix/matrix.scss
@@ -198,12 +198,8 @@
   padding: 0 1rem 3rem;
 }
 
-.matrix-console-shell__stack {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2rem;
+.matrix-console-shell > .hack-input-panel {
+  margin-top: -0.5rem;
 }
 
 /* Matrix Hero Panel */
@@ -1166,6 +1162,10 @@
     gap: 2.25rem;
   }
 
+  .matrix-console-shell > .hack-input-panel {
+    margin-top: -0.25rem;
+  }
+
   .matrix-hero__telemetry {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1176,6 +1176,10 @@
     width: 100%;
     padding: 0 1.25rem 2.5rem;
     gap: 2rem;
+  }
+
+  .matrix-console-shell > .hack-input-panel {
+    margin-top: -0.5rem;
   }
 
   .matrix-hero {
@@ -1199,10 +1203,6 @@
 
   .matrix-hero__stat {
     padding: 1.15rem 1.2rem;
-  }
-
-  .matrix-console-shell__stack {
-    gap: 1.5rem;
   }
 
   .hack-sequencer {


### PR DESCRIPTION
## **User description**
## Summary
- remove pnpm-only flags from the project .npmrc to stop npm from flagging them as unknown
- set the default npm loglevel to error so repository linting runs without configuration warnings and document where to reapply the pnpm options if needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5b1650b5c8333ba303e13b734189a


___

## **CodeAnt-AI Description**
Show hack progress and separate input; silence npm config warnings during lint

### What Changed
- The Matrix view now displays a dedicated hack sequencer with a labeled percentage, title that updates when complete, a visual progress bar, and a live-region announcement for assistive tech.
- The keystroke input was moved into its own input panel below the sequencer, showing a placeholder ("Mash the keys to amplify the breach"), an accessible label, helper text that switches to "Channel stabilized" when complete, and is disabled after completion.
- Layout and spacing adjusted so the input panel aligns consistently beneath the console across breakpoints.
- Project .npmrc no longer contains pnpm-only flags and sets npm's log level to error; this removes npm unknown-key warnings during lint and documents where to keep pnpm-specific settings.

### Impact
`✅ Fewer lint-time npm warnings`
`✅ Clearer hack progress announcements for screen readers`
`✅ Consistent input placement across screen sizes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
