### PR TITLE
Trigger Nu-uh-uh overlay on idle decay

### DIFF
--- a/src/assets/audio/didnt-say-the-magic-word.vtt
+++ b/src/assets/audio/didnt-say-the-magic-word.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00.000 --> 00:03.500
+Dennis Nedry says, "Uh-uh-uh! You didn't say the magic word!"

--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -5,10 +5,10 @@ import React, { useEffect, useRef, useState, useCallback, useMemo } from "react"
 import { useAuth } from "./AuthContext";
 
 // Components
+import NuUhUhEasterEgg from "./NuUhUhEasterEgg";
 
 // Styles
 import "./matrix.scss";
-import NuUhUhEasterEgg from "./NuUhUhEasterEgg";
 
 const MIN_FONT_SIZE = 12;
 const MAX_FONT_SIZE = 18;
@@ -107,14 +107,14 @@ const Matrix = ({ isVisible, onSuccess }) => {
 
   const handleHackInputChange = useCallback(
     (e) => {
-      if (isHackingComplete) {
+      if (isHackingComplete || showAccessDenied) {
         return;
       }
 
       const inputValue = e.target.value;
       setHackingBuffer(inputValue.slice(-64));
     },
-    [isHackingComplete, setHackingBuffer],
+    [isHackingComplete, setHackingBuffer, showAccessDenied],
   );
 
   const handleHackKeyDown = useCallback(
@@ -398,7 +398,7 @@ const Matrix = ({ isVisible, onSuccess }) => {
   }, [isVisible]);
 
   useEffect(() => {
-    if (!isVisible || isHackingComplete) {
+    if (!isVisible || isHackingComplete || showAccessDenied) {
       return undefined;
     }
 
@@ -489,6 +489,7 @@ const Matrix = ({ isVisible, onSuccess }) => {
   }, [
     isVisible,
     isHackingComplete,
+    showAccessDenied,
     setHackFeedback,
     setHackProgress,
     triggerIdleFailure,
@@ -779,7 +780,7 @@ const Matrix = ({ isVisible, onSuccess }) => {
               onKeyDown={handleHackKeyDown}
               placeholder="Mash the keys to amplify the breach"
               className="hack-input-field"
-              disabled={isHackingComplete}
+              disabled={isHackingComplete || showAccessDenied}
               aria-label="Hack input stream"
             />
             <div className="hack-input-helper" aria-hidden="true">

--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -8,6 +8,7 @@ import { useAuth } from "./AuthContext";
 
 // Styles
 import "./matrix.scss";
+import NuUhUhEasterEgg from "./NuUhUhEasterEgg";
 
 const MIN_FONT_SIZE = 12;
 const MAX_FONT_SIZE = 18;
@@ -96,7 +97,9 @@ const Matrix = ({ isVisible, onSuccess }) => {
   });
   const [signalSeed] = useState(() => Math.floor(Math.random() * 900) + 100);
   const lastKeyTimeRef = useRef(null);
+  const idleFailureTrackerRef = useRef({ lowStreak: 0 });
   const { completeHack, showSuccessFeedback } = useAuth();
+  const [showAccessDenied, setShowAccessDenied] = useState(false);
 
   // * Configuration constants
   const ALPHABET =
@@ -116,6 +119,10 @@ const Matrix = ({ isVisible, onSuccess }) => {
 
   const handleHackKeyDown = useCallback(
     (e) => {
+      if (showAccessDenied) {
+        return;
+      }
+
       if (isHackingComplete) {
         return;
       }
@@ -132,6 +139,8 @@ const Matrix = ({ isVisible, onSuccess }) => {
       if (!isCharacterKey && e.key !== "Backspace") {
         return;
       }
+
+      idleFailureTrackerRef.current.lowStreak = 0;
 
       const now = Date.now();
       const lastTime = lastKeyTimeRef.current;
@@ -168,7 +177,12 @@ const Matrix = ({ isVisible, onSuccess }) => {
       setHackFeedback(feedbackMessage);
       setHackProgress((prev) => Math.min(100, prev + increment));
     },
-    [isHackingComplete, setHackFeedback, setHackProgress],
+    [
+      isHackingComplete,
+      setHackFeedback,
+      setHackProgress,
+      showAccessDenied,
+    ],
   );
 
   const focusHackInput = useCallback(() => {
@@ -176,6 +190,42 @@ const Matrix = ({ isVisible, onSuccess }) => {
       hackInputRef.current?.focus({ preventScroll: true });
     });
   }, []);
+
+  const resetIdleFailureTracking = useCallback(() => {
+    idleFailureTrackerRef.current.lowStreak = 0;
+  }, []);
+
+  const triggerIdleFailure = useCallback(() => {
+    if (showAccessDenied) {
+      return;
+    }
+
+    resetIdleFailureTracking();
+    lastKeyTimeRef.current = null;
+    setHackFeedback("Signal severed. Access denied. Reinitialize the override.");
+    setShowAccessDenied(true);
+  }, [resetIdleFailureTracking, setHackFeedback, showAccessDenied]);
+
+  const handleDismissAccessDenied = useCallback(() => {
+    if (!showAccessDenied) {
+      return;
+    }
+
+    setShowAccessDenied(false);
+    resetIdleFailureTracking();
+    lastKeyTimeRef.current = null;
+    setHackProgress(0);
+    setHackingBuffer("");
+    setHackFeedback("Channel reset. Re-engage manual override.");
+    focusHackInput();
+  }, [
+    focusHackInput,
+    resetIdleFailureTracking,
+    setHackFeedback,
+    setHackProgress,
+    setHackingBuffer,
+    showAccessDenied,
+  ]);
 
   // * Handle keyboard shortcuts
   const handleKeyDown = useCallback(
@@ -361,6 +411,8 @@ const Matrix = ({ isVisible, onSuccess }) => {
           return;
         }
 
+        let shouldTriggerFailure = false;
+
         setHackProgress((prev) => {
           if (prev <= 0) {
             return prev;
@@ -385,10 +437,25 @@ const Matrix = ({ isVisible, onSuccess }) => {
 
           if (next === 0) {
             lastKeyTimeRef.current = null;
+            idleFailureTrackerRef.current.lowStreak = 0;
+            shouldTriggerFailure = true;
+          } else if (next < 8) {
+            idleFailureTrackerRef.current.lowStreak += 1;
+
+            if (idleFailureTrackerRef.current.lowStreak >= 3) {
+              shouldTriggerFailure = true;
+              idleFailureTrackerRef.current.lowStreak = 0;
+            }
+          } else {
+            idleFailureTrackerRef.current.lowStreak = 0;
           }
 
           return next;
         });
+
+        if (shouldTriggerFailure) {
+          triggerIdleFailure();
+        }
       };
 
       if (lastTime === null) {
@@ -424,6 +491,7 @@ const Matrix = ({ isVisible, onSuccess }) => {
     isHackingComplete,
     setHackFeedback,
     setHackProgress,
+    triggerIdleFailure,
   ]);
 
   useEffect(() => {
@@ -433,6 +501,13 @@ const Matrix = ({ isVisible, onSuccess }) => {
 
     focusHackInput();
   }, [isVisible, showSuccessFeedback, focusHackInput]);
+
+  useEffect(() => {
+    if (!isVisible) {
+      setShowAccessDenied(false);
+      resetIdleFailureTracking();
+    }
+  }, [isVisible, resetIdleFailureTracking]);
 
 
 
@@ -729,7 +804,7 @@ const Matrix = ({ isVisible, onSuccess }) => {
           <span key={hint}>{hint}</span>
         ))}
       </div>
-
+      {showAccessDenied && <NuUhUhEasterEgg onClose={handleDismissAccessDenied} />}
     </dialog>
   );
 };

--- a/src/components/effects/Matrix/NuUhUhEasterEgg.jsx
+++ b/src/components/effects/Matrix/NuUhUhEasterEgg.jsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+import deniedAudio from "../../../assets/audio/didn't-say-the-magic-word.mp3";
+import deniedImage from "../../../assets/images/nu-uh-uh.webp";
+import deniedCaptions from "../../../assets/audio/didnt-say-the-magic-word.vtt";
+
+const NuUhUhEasterEgg = ({ onClose }) => {
+  const audioRef = useRef(null);
+  const overlayRef = useRef(
+    typeof document !== "undefined" ? document.createElement("div") : null,
+  );
+
+  useEffect(() => {
+    const overlayNode = overlayRef.current;
+
+    if (!overlayNode || typeof document === "undefined") {
+      return undefined;
+    }
+
+    overlayNode.className = "nuuhuh-overlay";
+    document.body.appendChild(overlayNode);
+
+    return () => {
+      if (overlayNode.parentNode) {
+        overlayNode.parentNode.removeChild(overlayNode);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  useEffect(() => {
+    const audioElement = audioRef.current;
+    if (!audioElement) {
+      return undefined;
+    }
+
+    const handleEnded = () => {
+      onClose?.();
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onClose?.();
+      }
+    };
+
+    const attemptPlayback = async () => {
+      try {
+        await audioElement.play();
+      } catch (error) {
+        console.warn("Audio playback failed", error);
+      }
+    };
+
+    attemptPlayback();
+
+    audioElement.addEventListener("ended", handleEnded);
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      audioElement.pause();
+      audioElement.currentTime = 0;
+      audioElement.removeEventListener("ended", handleEnded);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  if (!overlayRef.current || typeof document === "undefined") {
+    return null;
+  }
+
+  const handleBackdropKeyDown = (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onClose?.();
+    }
+  };
+
+  return createPortal(
+    <>
+      <div
+        className="nuuhuh-overlay__backdrop"
+        role="button"
+        tabIndex={0}
+        aria-label="Dismiss access denied Easter egg"
+        onClick={onClose}
+        onKeyDown={handleBackdropKeyDown}
+      />
+      <dialog
+        open
+        className="nuuhuh-overlay__content glitch-effect"
+        aria-label="Access denied Easter egg"
+      >
+        <img
+          src={deniedImage}
+          alt="Dennis Nedry from Jurassic Park saying 'uh-uh-uh, you didn't say the magic word'"
+          className="nuuhuh-overlay__image"
+        />
+        <p className="nuuhuh-overlay__message">Access Denied</p>
+        <p className="nuuhuh-overlay__hint">Nu-uh-uh! You didn't say the magic word.</p>
+        <button type="button" className="nuuhuh-overlay__close-btn" onClick={onClose}>
+          Dismiss
+        </button>
+        <audio ref={audioRef} src={deniedAudio} preload="auto">
+          <track
+            kind="captions"
+            src={deniedCaptions}
+            srcLang="en"
+            label="English captions"
+            default
+          />
+        </audio>
+      </dialog>
+    </>,
+    overlayRef.current,
+  );
+};
+
+export default NuUhUhEasterEgg;

--- a/src/components/effects/Matrix/PasscodeInput.jsx
+++ b/src/components/effects/Matrix/PasscodeInput.jsx
@@ -1,25 +1,68 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useAuth } from "./AuthContext";
+import NuUhUhEasterEgg from "./NuUhUhEasterEgg";
 
 const PasscodeInput = () => {
   const { isUnlocked, logout } = useAuth();
+  const [showAccessDenied, setShowAccessDenied] = useState(false);
 
-  if (isUnlocked) {
-    return (
-      <div className="passcode-widget">
-        <span className="auth-state">Authenticated</span>
-        <button type="button" className="logout-btn" onClick={logout}>
-          Logout
-        </button>
-      </div>
-    );
-  }
+  const handleShowAccessDenied = useCallback(() => {
+    setShowAccessDenied(true);
+  }, []);
+
+  const handleHideAccessDenied = useCallback(() => {
+    setShowAccessDenied(false);
+  }, []);
+
+  useEffect(() => {
+    const handleKeydown = (event) => {
+      if (
+        !showAccessDenied &&
+        event.altKey &&
+        (event.ctrlKey || event.metaKey) &&
+        event.key.toLowerCase() === "n"
+      ) {
+        event.preventDefault();
+        handleShowAccessDenied();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeydown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeydown);
+    };
+  }, [handleShowAccessDenied, showAccessDenied]);
 
   return (
-    <div className="passcode-widget" aria-live="polite">
-      <span className="auth-state">Matrix override required</span>
-      <span className="auth-hint">Launch the Matrix console to authenticate.</span>
-    </div>
+    <>
+      {isUnlocked ? (
+        <div className="passcode-widget">
+          <span className="auth-state">Authenticated</span>
+          <button type="button" className="logout-btn" onClick={logout}>
+            Logout
+          </button>
+        </div>
+      ) : (
+        <div className="passcode-widget" aria-live="polite">
+          <span className="auth-state">Matrix override required</span>
+          <span className="auth-hint">Launch the Matrix console to authenticate.</span>
+          <span className="auth-easter-egg-hint">
+            Press <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Alt</kbd> + <kbd>N</kbd> or use the
+            button below to replay the classic access denied moment.
+          </span>
+          <button
+            type="button"
+            className="access-denied-btn"
+            onClick={handleShowAccessDenied}
+            aria-label="Trigger the access denied Easter egg"
+          >
+            Trigger Access Denied
+          </button>
+        </div>
+      )}
+      {showAccessDenied && <NuUhUhEasterEgg onClose={handleHideAccessDenied} />}
+    </>
   );
 };
 

--- a/src/components/effects/Matrix/matrix.scss
+++ b/src/components/effects/Matrix/matrix.scss
@@ -733,6 +733,158 @@
   }
 }
 
+/* Access denied Easter egg overlay */
+.nuuhuh-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal-controls, 2100);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.nuuhuh-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(4px);
+  pointer-events: auto;
+}
+
+.nuuhuh-overlay__content {
+  position: relative;
+  z-index: 1;
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
+  border-radius: 12px;
+  border: 1.5px solid var(--matrix-green);
+  background: linear-gradient(145deg, rgba(0, 0, 0, 0.95), rgba(0, 32, 0, 0.92));
+  box-shadow:
+    0 0 20px rgba(0, 255, 0, 0.25),
+    0 0 40px rgba(0, 80, 0, 0.3);
+  animation: fadeIn 0.35s ease-out;
+  text-align: center;
+}
+
+.nuuhuh-overlay__content.glitch-effect {
+  animation:
+    fadeIn 0.35s ease-out,
+    enhancedGlitch 0.45s infinite;
+}
+
+.nuuhuh-overlay__image {
+  max-width: min(320px, 80vw);
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow:
+    0 0 15px rgba(0, 255, 0, 0.15),
+    0 0 30px rgba(0, 255, 0, 0.1);
+}
+
+.nuuhuh-overlay__message {
+  margin-top: 1.25rem;
+  color: var(--matrix-white);
+  font-family: "Courier New", monospace;
+  font-size: 1.25rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-shadow: 0 0 10px var(--matrix-green);
+}
+
+.nuuhuh-overlay__hint {
+  margin-top: 0.5rem;
+  color: var(--matrix-green);
+  font-family: "Courier New", monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+}
+
+.nuuhuh-overlay__close-btn {
+  margin-top: 1.5rem;
+  padding: 0.6rem 1.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--matrix-green);
+  background: transparent;
+  color: var(--matrix-green);
+  font-family: "Courier New", monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all var(--matrix-transition);
+  text-shadow: 0 0 6px rgba(0, 255, 0, 0.5);
+}
+
+.nuuhuh-overlay__close-btn:hover,
+.nuuhuh-overlay__close-btn:focus {
+  background: var(--matrix-green);
+  color: rgb(0 0 0 / 85%);
+  box-shadow:
+    0 0 15px rgba(0, 255, 0, 0.4),
+    0 0 30px rgba(0, 255, 0, 0.35);
+}
+
+.nuuhuh-overlay__close-btn:focus {
+  outline: 2px solid var(--matrix-white);
+  outline-offset: 3px;
+}
+
+/* Passcode widget trigger */
+.passcode-widget .auth-easter-egg-hint {
+  display: block;
+  margin-top: 0.75rem;
+  color: rgba(0, 255, 0, 0.7);
+  font-family: "Courier New", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  line-height: 1.6;
+}
+
+.passcode-widget .auth-easter-egg-hint kbd {
+  display: inline-block;
+  padding: 0.1rem 0.4rem;
+  margin: 0 0.15rem;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 255, 0, 0.4);
+  background: rgb(0 0 0 / 25%);
+  color: var(--matrix-white);
+  font-size: 0.7rem;
+  font-family: inherit;
+  box-shadow: 0 0 6px rgba(0, 255, 0, 0.2);
+}
+
+.passcode-widget .access-denied-btn {
+  margin-top: 0.75rem;
+  padding: 0.45rem 1.1rem;
+  border-radius: 8px;
+  border: 1px solid var(--matrix-green);
+  background: rgb(0 0 0 / 30%);
+  color: var(--matrix-green);
+  font-family: "Courier New", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all var(--matrix-transition);
+}
+
+.passcode-widget .access-denied-btn:hover,
+.passcode-widget .access-denied-btn:focus {
+  background: rgba(0, 255, 0, 0.2);
+  color: var(--matrix-white);
+  box-shadow: 0 0 10px rgba(0, 255, 0, 0.25);
+}
+
+.passcode-widget .access-denied-btn:focus {
+  outline: 2px solid var(--matrix-white);
+  outline-offset: 3px;
+}
+
 /* Matrix container glitch effect */
 .matrix-container.glitch-effect {
   animation: matrixContainerGlitch 0.5s ease-in-out;


### PR DESCRIPTION
## **User description**
## Summary
- fire the Nu-uh-uh access denied overlay when the Matrix console's idle decay collapses progress
- block hack input while the overlay is visible and reset the session once it is dismissed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5bdef01b48333972de3febf491a13


___

## **CodeAnt-AI Description**
Show "Access Denied" overlay and reset Matrix session when idle progress collapses

### What Changed
- When the Matrix console progress decays to zero or repeatedly drops very low, the app now displays a full-screen "Access Denied" overlay with image, audio (with captions) and a glitch visual that blocks hack input until dismissed.
- While the overlay is visible, keyboard and hack input are ignored so users cannot continue typing into the Matrix console; dismissing the overlay resets the session (progress cleared, input buffer cleared) and returns focus to the hack input with a reset message.
- The Passcode widget now shows a hint, a button, and a keyboard shortcut (Ctrl/Cmd + Alt + N) so users can manually replay the classic "You didn't say the magic word" moment.
- The overlay can be dismissed by clicking the backdrop, pressing the Dismiss button, pressing Escape, pressing Enter/Space on the backdrop, or when the audio ends; body scrolling is disabled while the overlay is open.
- New styling and captions support are included so the overlay presents the image, audio, and accessible captions consistently across view sizes.

### Impact
`✅ Clearer access denied feedback when Matrix stalls`
`✅ Blocked hack input during access-denied overlay`
`✅ Replayable classic audio via shortcut or button`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
