### PR TITLE
Add test for default generateItemColors keyword cycling

### DIFF
--- a/src/utils/__tests__/colorUtils.test.js
+++ b/src/utils/__tests__/colorUtils.test.js
@@ -78,5 +78,26 @@ describe("colorUtils", () => {
         second: defaultHsl[1],
       });
     });
+
+    it("defaults to the keyword property and cycles colors like generateTagColors", () => {
+      const items = [
+        { keyword: "alpha" },
+        { keyword: "beta" },
+        { keyword: "gamma" },
+        { keyword: "alpha" },
+        { keyword: "delta" },
+        { keyword: "epsilon" },
+        { keyword: "zeta" },
+        { keyword: "eta" },
+        { keyword: "theta" },
+        { keyword: "iota" },
+      ];
+
+      const result = generateItemColors(items);
+      const uniqueKeywords = [...new Set(items.map((item) => item.keyword))];
+      const expectedColors = generateTagColors(uniqueKeywords);
+
+      expect(result).toEqual(expectedColors);
+    });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary
- add coverage ensuring generateItemColors defaults to keyword keys and mirrors generateTagColors color cycling

## Testing
- CI=true npm test -- --runTestsByPath src/utils/__tests__/colorUtils.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f5c89d3c5c8333b090253f2d286ba4


___

## **CodeAnt-AI Description**
**Add test to ensure items use keyword for colors and match tag color cycling**

### What Changed
- Adds a unit test that verifies generateItemColors falls back to each item's keyword when no key argument is provided
- Confirms the color mapping for the unique keywords cycles exactly the same way as generateTagColors, including when items repeat
- Prevents unnoticed changes to color assignment behavior by failing the test if keyword defaulting or color cycling changes

### Impact
`✅ Fewer color regressions in item lists`
`✅ Consistent colors between tags and items`
`✅ Faster detection of color-mapping regressions in tests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
