### PR TITLE
Add interaction coverage to Header chat bubble tests

### DIFF
--- a/src/components/content/Header/Header.test.js
+++ b/src/components/content/Header/Header.test.js
@@ -4,16 +4,45 @@ jest.mock("./useScrambleEffect", () => jest.fn());
 
 import Header from "./Header";
 
-describe("ChatBubble accessibility", () => {
-  it("does not throw when activated via keyboard", () => {
+describe("ChatBubble interactions", () => {
+  it("reveals the first hint and updates the prompt when activated via keyboard", () => {
     const { container } = render(<Header />);
     const chatBubble = container.querySelector(".chat-bubble");
+    const firstHint = container.querySelector(".hint-section.first");
+    let prompt = container.querySelector(".hint-prompt");
 
     expect(chatBubble).not.toBeNull();
+    expect(firstHint).not.toBeNull();
+    expect(prompt).not.toBeNull();
+    expect(firstHint.classList.contains("visible")).toBe(false);
+    expect(prompt.textContent).toBe("Tap for more...");
 
-    // Ensure no errors occur when triggering the keyboard interaction.
-    expect(() => {
-      fireEvent.keyUp(chatBubble, { key: "Enter" });
-    }).not.toThrow();
+    fireEvent.keyUp(chatBubble, { key: "Enter" });
+
+    expect(firstHint.classList.contains("visible")).toBe(true);
+    prompt = container.querySelector(".hint-prompt");
+    expect(prompt).not.toBeNull();
+    expect(prompt.textContent).toBe("One more line...");
+  });
+
+  it("advances hints up to the maximum level on repeated interactions", () => {
+    const { container } = render(<Header />);
+    const chatBubble = container.querySelector(".chat-bubble");
+    const secondHint = container.querySelector(".hint-section.second");
+
+    expect(chatBubble).not.toBeNull();
+    expect(secondHint).not.toBeNull();
+    expect(secondHint.classList.contains("visible")).toBe(false);
+
+    fireEvent.click(chatBubble);
+    fireEvent.click(chatBubble);
+
+    expect(secondHint.classList.contains("visible")).toBe(true);
+    expect(container.querySelector(".hint-prompt")).toBeNull();
+
+    fireEvent.click(chatBubble);
+
+    expect(chatBubble.classList.contains("level-2")).toBe(true);
+    expect(chatBubble.classList.contains("level-3")).toBe(false);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary
- ensure the Header chat bubble updates hint visibility and prompt text after keyboard interaction
- cover repeated interactions to confirm the hint sequence reaches its maximum level

## Testing
- CI=true npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68f5d20a504c83339d8f5c6ead5ca1d8


___

## **CodeAnt-AI Description**
**Ensure Header chat bubble reveals hints, updates prompt, and stops advancing past the final level**

### What Changed
- Activating the header chat bubble with the keyboard now reveals the first hint and changes the hint prompt text from "Tap for more..." to "One more line..."
- Repeated clicks advance the hint sequence: after two clicks the second hint becomes visible and the hint prompt is removed
- A further click puts the chat bubble into the second visual level and it does not advance to a third level

### Impact
`✅ Keyboard activation reveals first hint and updates prompt`
`✅ Repeated taps reveal next hint then remove the prompt`
`✅ Chat bubble reaches and stays at the final visual level`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
