### PR TITLE
Handle theme color regeneration for projects

### DIFF
--- a/src/components/content/Projects/Projects.js
+++ b/src/components/content/Projects/Projects.js
@@ -65,20 +65,58 @@ function Projects(props) {
   const [tagColors, setTagColors] = useState({});
 
   useEffect(() => {
+    const projectsData = props.db.projects ?? [];
     const uniqueKeywords = [
-      ...new Set(props.db.projects.map((project) => project.keyword)),
+      ...new Set(projectsData.map((project) => project.keyword)),
     ];
 
-    const generatedTagColors = generateItemColors(props.db.projects, "keyword");
+    const generatedTagColors = generateItemColors(projectsData, "keyword");
     setTagColors(generatedTagColors);
-    setActiveFilters(uniqueKeywords);
+    setActiveFilters((prevFilters) => {
+      if (prevFilters.length === 0) {
+        return uniqueKeywords;
+      }
+
+      const filtered = prevFilters.filter((filter) =>
+        uniqueKeywords.includes(filter),
+      );
+
+      if (filtered.length === 0) {
+        return uniqueKeywords;
+      }
+
+      return filtered;
+    });
   }, [props.db.projects]);
 
   // Add theme change listener
   useEffect(() => {
     const handleThemeChange = () => {
-      // Re-trigger the color generation effect
-      setTagColors({}); // This will cause the first useEffect to run again
+      const projectsData = props.db.projects ?? [];
+      const uniqueKeywords = [
+        ...new Set(projectsData.map((project) => project.keyword)),
+      ];
+
+      const regeneratedTagColors = generateItemColors(
+        projectsData,
+        "keyword",
+      );
+      setTagColors(regeneratedTagColors);
+      setActiveFilters((prevFilters) => {
+        if (prevFilters.length === 0) {
+          return uniqueKeywords;
+        }
+
+        const filtered = prevFilters.filter((filter) =>
+          uniqueKeywords.includes(filter),
+        );
+
+        if (filtered.length === 0) {
+          return uniqueKeywords;
+        }
+
+        return filtered;
+      });
     };
 
     // Listen for theme changes
@@ -87,7 +125,7 @@ function Projects(props) {
     return () => {
       document.body.removeEventListener("theme-changed", handleThemeChange);
     };
-  }, []);
+  }, [props.db.projects]);
 
   const toggleFilter = useCallback(
     (filter) => {

--- a/src/components/content/Projects/Projects.test.js
+++ b/src/components/content/Projects/Projects.test.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+
+import Projects from "./Projects";
+import { generateItemColors } from "../../../utils/colorUtils";
+
+jest.mock("react-db-google-sheets", () => ({
+  withGoogleSheets: () => (Component) => Component,
+}));
+
+jest.mock("../../../utils/colorUtils", () => {
+  const actual = jest.requireActual("../../../utils/colorUtils");
+  return {
+    ...actual,
+    generateItemColors: jest.fn(),
+  };
+});
+
+const MOCK_PROJECTS = [
+  {
+    title: "Project One",
+    slug: "project-one",
+    date: "2024",
+    keyword: "React",
+    link: "https://example.com/react",
+    content: "React project",
+    image: null,
+  },
+  {
+    title: "Project Two",
+    slug: "project-two",
+    date: "2023",
+    keyword: "Node",
+    link: "https://example.com/node",
+    content: "Node project",
+    image: null,
+  },
+];
+
+describe("Projects", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("regenerates tag colors when the theme changes", async () => {
+    generateItemColors
+      .mockImplementationOnce(() => ({
+        React: "hsl(0, 0%, 50%)",
+        Node: "hsl(120, 100%, 50%)",
+      }))
+      .mockImplementation(() => ({
+        React: "hsl(200, 60%, 55%)",
+        Node: "hsl(40, 80%, 60%)",
+      }));
+
+    render(<Projects db={{ projects: MOCK_PROJECTS }} />);
+
+    const reactFilter = await screen.findByRole("button", { name: "React" });
+
+    await waitFor(() => {
+      expect(reactFilter.style.borderLeft).toBe(
+        "4px solid hsl(0, 0%, 50%)",
+      );
+    });
+
+    act(() => {
+      document.body.dispatchEvent(new CustomEvent("theme-changed"));
+    });
+
+    expect(generateItemColors).toHaveBeenCalledTimes(2);
+    expect(generateItemColors).toHaveBeenLastCalledWith(
+      MOCK_PROJECTS,
+      "keyword",
+    );
+
+    await waitFor(() => {
+      expect(reactFilter.style.borderLeft).toBe(
+        "4px solid hsl(200, 60%, 55%)",
+      );
+      expect(reactFilter.className).toContain("active");
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary
- regenerate project tag colors when the theme changes instead of resetting state
- keep active project filters aligned with available keywords during color refreshes
- add a regression test that simulates the theme change event and verifies color updates

## Testing
- CI=true npm test -- Projects

------
https://chatgpt.com/codex/tasks/task_e_68f5d20220308333b5f70863bc2c6ab8


___

## **CodeAnt-AI Description**
**Regenerate project tag colors on theme change and preserve selected filters**

### What Changed
- When the app theme changes, project tag colors are recalculated immediately and the UI updates to show the new colors instead of resetting state.
- Selected project filters are kept after a theme change; if a previously selected filter no longer exists the filter set falls back to the available keywords.
- The component now tolerates a missing or empty projects list and uses current project data when regenerating colors, avoiding errors or empty states.
- The theme-change handler is updated so color updates use the latest projects list when projects change.
- Adds a unit test that simulates a theme change, verifies colors are regenerated, and checks the active filter remains selected.

### Impact
`✅ Clearer tag colors after theme change`
`✅ Fewer lost filter selections on theme switch`
`✅ No errors when project list is missing`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
