### PR TITLE
Fix Matrix ready callback wiring

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -308,8 +308,17 @@ const AppContent = () => {
   // Matrix ready callback - will be set by Matrix component
   const matrixReadyCallbackRef = useRef(null);
   const handleMatrixReady = useCallback((callback) => {
-    matrixReadyCallbackRef.current = callback;
+    matrixReadyCallbackRef.current =
+      typeof callback === "function" ? callback : null;
   }, []);
+
+  useEffect(() => {
+    if (!showMatrix) {
+      return;
+    }
+
+    matrixReadyCallbackRef.current?.();
+  }, [showMatrix]);
 
   // --- Render ---
   return (

--- a/src/components/effects/Matrix/Matrix.js
+++ b/src/components/effects/Matrix/Matrix.js
@@ -133,7 +133,7 @@ const useHackSession = (isVisible) => {
   };
 };
 
-const Matrix = ({ isVisible, onSuccess }) => {
+const Matrix = ({ isVisible, onSuccess, onMatrixReady }) => {
   const canvasRef = useRef(null);
   const {
     hackingBuffer,
@@ -321,6 +321,18 @@ const Matrix = ({ isVisible, onSuccess }) => {
       hackInputRef.current?.focus({ preventScroll: true });
     });
   }, []);
+
+  useEffect(() => {
+    if (!onMatrixReady) {
+      return undefined;
+    }
+
+    onMatrixReady(focusHackInput);
+
+    return () => {
+      onMatrixReady(null);
+    };
+  }, [onMatrixReady, focusHackInput]);
 
   const resetIdleFailureTracking = useCallback(() => {
     idleFailureTrackerRef.current.lowStreak = 0;


### PR DESCRIPTION
## **User description**
## Summary
- ensure the Matrix effect notifies callers when its imperative handle is ready
- only store valid callbacks and invoke them when the Matrix modal opens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5ebcb34688333be90f99bb45cddb5

## Summary by Sourcery

Wire up the Matrix effect’s ready callback by exposing onMatrixReady in the Matrix component, registering the focusHackInput handle in App, and invoking it when the Matrix modal becomes visible

New Features:
- Add onMatrixReady prop to Matrix component to register its focusHackInput handle
- Trigger the registered Matrix ready callback in App when the Matrix modal opens

Enhancements:
- Validate and clear non-function callbacks in App’s handleMatrixReady


___

## **CodeAnt-AI Description**
**Auto-focus Matrix modal input on open and validate ready callback**

### What Changed
- When the Matrix modal opens, the modal's input is automatically focused so users can start typing without clicking.
- The Matrix component now exposes a ready callback that App registers; App invokes that callback when the modal becomes visible to trigger the focus.
- App ignores and clears any non-function callbacks to avoid runtime errors.
- The ready callback is cleared when the Matrix component unmounts so stale callbacks are not invoked later.

### Impact
`✅ Immediate input focus when Matrix modal opens`
`✅ Fewer focus-related errors on modal open`
`✅ No stale callbacks after Matrix closes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
