### PR TITLE
Add filter toggle coverage to Projects tests

### DIFF
--- a/src/components/content/Projects/Projects.test.js
+++ b/src/components/content/Projects/Projects.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import Projects from "./Projects";
 import { generateItemColors } from "../../../utils/colorUtils";
@@ -78,6 +79,45 @@ describe("Projects", () => {
         "4px solid hsl(200, 60%, 55%)",
       );
       expect(reactFilter.className).toContain("active");
+    });
+  });
+
+  it("filters projects by keyword and restores cards when toggling the last active filter", async () => {
+    generateItemColors.mockReturnValue({
+      React: "hsl(0, 0%, 50%)",
+      Node: "hsl(120, 100%, 50%)",
+    });
+
+    const user = userEvent.setup();
+
+    render(<Projects db={{ projects: MOCK_PROJECTS }} />);
+
+    const reactFilter = await screen.findByRole("button", { name: "React" });
+    const nodeFilter = await screen.findByRole("button", { name: "Node" });
+
+    const reactProject = screen.getByRole("link", { name: /Project One/i });
+    const nodeProject = screen.getByRole("link", { name: /Project Two/i });
+
+    await act(async () => {
+      await user.click(reactFilter);
+    });
+
+    await waitFor(() => {
+      expect(reactFilter.className).not.toContain("active");
+      expect(nodeFilter.className).toContain("active");
+      expect(reactProject.className).toContain("filtered-out");
+      expect(nodeProject.className).not.toContain("filtered-out");
+    });
+
+    await act(async () => {
+      await user.click(nodeFilter);
+    });
+
+    await waitFor(() => {
+      expect(reactFilter.className).toContain("active");
+      expect(nodeFilter.className).toContain("active");
+      expect(reactProject.className).not.toContain("filtered-out");
+      expect(nodeProject.className).not.toContain("filtered-out");
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary
- add an interaction test for the Projects component to verify filter toggling hides and reveals cards

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68f69bcaa17c8333b19cbba09bca8185

## Summary by Sourcery

Tests:
- Add a test that mocks item colors, toggles React and Node filters, and verifies project cards are filtered out and restored as expected


___

## **CodeAnt-AI Description**
**Add test that verifies project filters hide and restore project cards**

### What Changed
- Adds an interaction test that simulates clicking project filter buttons and asserts how project cards are shown or hidden
- Confirms that activating the React filter hides React project cards while Node project cards remain visible
- Confirms that toggling the last active filter restores previously hidden project cards, exercising the full hide-and-restore flow

### Impact
`✅ Fewer regressions in project filtering`
`✅ Clearer filter toggle failures in CI`
`✅ Faster debugging for filter UI issues`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
