### PR TITLE
🔒 Disable source maps in production

### DIFF
--- a/config/craco.config.js
+++ b/config/craco.config.js
@@ -42,7 +42,7 @@ module.exports = {
       loaderOptions: {
         implementation: require("sass"),
         api: "modern",
-        sourceMap: true,
+        sourceMap: process.env.NODE_ENV !== "production",
         sassOptions: {
           outputStyle:
             process.env.NODE_ENV === "production" ? "compressed" : "expanded",
@@ -57,12 +57,12 @@ module.exports = {
     },
     css: {
       loaderOptions: {
-        sourceMap: true,
+        sourceMap: process.env.NODE_ENV !== "production",
       },
     },
     postcss: {
       loaderOptions: {
-        sourceMap: true,
+        sourceMap: process.env.NODE_ENV !== "production",
       },
     },
   },


### PR DESCRIPTION
## **User description**
🎯 **What:** Disabled source map generation for Sass, CSS, and PostCSS in production builds.
⚠️ **Risk:** Enabling source maps in production exposes the original source code, which can be used by attackers to understand the application logic and find vulnerabilities.
🛡️ **Solution:** Modified `config/craco.config.js` to conditionally set `sourceMap` to `process.env.NODE_ENV !== "production"`.


---
*PR created automatically by Jules for task [9232274737616478006](https://jules.google.com/task/9232274737616478006) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Make Sass, CSS, and PostCSS source map generation conditional on NODE_ENV so they are only enabled outside production.


___

## **CodeAnt-AI Description**
**Disable Sass/CSS/PostCSS source maps in production builds**

### What Changed
- Sass, CSS, and PostCSS now only generate source maps when NODE_ENV is not "production"
- Production builds no longer include source maps, while development builds keep them enabled

### Impact
`✅ Prevents source code exposure in production`
`✅ Smaller production build artifacts`
`✅ Fewer accidental source leaks in deployed apps`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
