### PR TITLE
🔒 Fix insufficient input validation in Notion API proxy

### DIFF
--- a/api/notion.js
+++ b/api/notion.js
@@ -96,6 +96,91 @@ function transformAboutData(results) {
   });
 }
 
+// Validate sorts array
+function validateSorts(sorts) {
+  if (!Array.isArray(sorts)) return undefined;
+  return sorts.map((sort) => {
+    if (!sort || typeof sort !== "object") return null;
+    const { property, timestamp, direction } = sort;
+
+    // Only allow 'ascending' or 'descending'
+    if (direction !== "ascending" && direction !== "descending") return null;
+
+    const newSort = { direction };
+
+    if (typeof property === "string") {
+      newSort.property = property;
+    } else if (timestamp === "created_time" || timestamp === "last_edited_time") {
+      newSort.timestamp = timestamp;
+    } else {
+      return null;
+    }
+    return newSort;
+  }).filter(Boolean);
+}
+
+// Allowed filter types (Notion API v1)
+const ALLOWED_FILTER_TYPES = [
+  "title", "rich_text", "url", "email", "phone_number", "number",
+  "checkbox", "select", "multi_select", "status", "date", "people",
+  "files", "relation"
+];
+
+// Validate filter object (recursive with depth limit)
+function validateFilter(filter, depth = 0) {
+  if (depth > 2) return null; // Prevent deep nesting/DoS
+  if (!filter || typeof filter !== "object") return null;
+
+  // Handle compound filters
+  if (Array.isArray(filter.and)) {
+    const validAnd = filter.and.map((f) => validateFilter(f, depth + 1)).filter(Boolean);
+    return validAnd.length > 0 ? { and: validAnd } : null;
+  }
+  if (Array.isArray(filter.or)) {
+    const validOr = filter.or.map((f) => validateFilter(f, depth + 1)).filter(Boolean);
+    return validOr.length > 0 ? { or: validOr } : null;
+  }
+
+  // Handle property filters
+  if (typeof filter.property === "string") {
+    const newFilter = { property: filter.property };
+    let hasType = false;
+
+    for (const key of Object.keys(filter)) {
+      if (ALLOWED_FILTER_TYPES.includes(key) && filter[key] && typeof filter[key] === "object") {
+         // Deep copy the condition object to prevent prototype pollution or weird getters
+         try {
+           newFilter[key] = JSON.parse(JSON.stringify(filter[key]));
+           hasType = true;
+         } catch (e) {
+           continue;
+         }
+      }
+    }
+
+    return hasType ? newFilter : null;
+  }
+
+  // Also support timestamp filters (created_time, last_edited_time)
+  if (filter.timestamp === "created_time" || filter.timestamp === "last_edited_time") {
+      const newFilter = { timestamp: filter.timestamp };
+      if (filter.created_time && typeof filter.created_time === "object") {
+          try {
+              newFilter.created_time = JSON.parse(JSON.stringify(filter.created_time));
+              return newFilter;
+          } catch (e) { return null; }
+      }
+      if (filter.last_edited_time && typeof filter.last_edited_time === "object") {
+          try {
+              newFilter.last_edited_time = JSON.parse(JSON.stringify(filter.last_edited_time));
+              return newFilter;
+          } catch (e) { return null; }
+      }
+  }
+
+  return null;
+}
+
 // Validate and sanitize the request body
 function validateQueryBody(body) {
   if (!body || typeof body !== "object") return { page_size: 100 };
@@ -105,12 +190,21 @@ function validateQueryBody(body) {
   } else {
     validated.page_size = 100;
   }
+
   if (body.filter && typeof body.filter === "object") {
-    validated.filter = body.filter;
+    const validFilter = validateFilter(body.filter);
+    if (validFilter) {
+      validated.filter = validFilter;
+    }
   }
+
   if (body.sorts && Array.isArray(body.sorts)) {
-    validated.sorts = body.sorts;
+    const validSorts = validateSorts(body.sorts);
+    if (validSorts && validSorts.length > 0) {
+      validated.sorts = validSorts;
+    }
   }
+
   return validated;
 }
 


### PR DESCRIPTION
## **User description**
🎯 **What:** Fixed an "Insufficient Input Validation" vulnerability in the Notion API proxy (`api/notion.js`) by implementing strict input validation for `filter` and `sorts` parameters.

⚠️ **Risk:** Previously, the `validateQueryBody` function allowed arbitrary objects to be passed to the external Notion API, which could be exploited to send malicious payloads, potentially leading to injection attacks or Denial of Service (DoS) via deeply nested structures.

🛡️ **Solution:**
- Implemented `validateFilter` helper: Recursively validates filter objects with a maximum depth of 2 (to prevent stack overflow/DoS) and whitelists allowed property types (e.g., `text`, `select`, `date`) and compound operators (`and`, `or`). It deep-copies valid structures to sanitize inputs.
- Implemented `validateSorts` helper: Enforces that the sorts array only contains valid sort objects with allowed `direction` ("ascending", "descending") and `property` or `timestamp` keys.
- Updated `validateQueryBody`: Now uses these helpers to strictly sanitize the request body before forwarding it to Notion, preserving legitimate functionality while rejecting malicious data.

Manual verification with a custom script confirmed that malicious payloads are sanitized and valid queries are preserved.

---
*PR created automatically by Jules for task [2486941494925506142](https://jules.google.com/task/2486941494925506142) started by @guitarbeat*


___

## **CodeAnt-AI Description**
Reject and sanitize invalid Notion query filters and sorts before forwarding

### What Changed
- Filters are now checked against a whitelist of allowed property types and compound operators; deeply nested filters beyond two levels are rejected.
- Filter objects are deep-copied and only valid condition shapes are preserved, so malformed or unsafe structures are not forwarded.
- Sort entries are validated to allow only "ascending" or "descending" directions and either a property name or an allowed timestamp; invalid sorts are dropped.
- The proxy returns only sanitized query bodies (including validated sorts/filters) to the Notion API instead of forwarding arbitrary client payloads.

### Impact
`✅ Fewer malformed requests forwarded to Notion`
`✅ Reduced risk of Denial-of-Service from deeply nested filters`
`✅ Fewer Notion API errors caused by invalid sort/filter inputs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
