### PR TITLE
Refactor NotionService to remove unused transformation functions

### DIFF
--- a/src/services/__tests__/notionService.test.ts
+++ b/src/services/__tests__/notionService.test.ts
@@ -1,0 +1,93 @@
+import NotionService from '../notionService';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('NotionService', () => {
+  let notionService: NotionService;
+
+  beforeEach(() => {
+    notionService = new NotionService();
+    mockFetch.mockClear();
+    // Reset process.env.REACT_APP_API_BASE if needed, but it defaults to "" in the file
+  });
+
+  it('should fetch projects correctly', async () => {
+    const mockData = [{ id: 1, title: 'Project 1' }];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const result = await notionService.getProjects();
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/notion?database=projects', {
+      method: 'GET',
+    });
+    expect(result).toEqual(mockData);
+  });
+
+  it('should fetch work correctly', async () => {
+    const mockData = [{ id: 1, company: 'Company A' }];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const result = await notionService.getWork();
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/notion?database=work', {
+      method: 'GET',
+    });
+    expect(result).toEqual(mockData);
+  });
+
+  it('should fetch about correctly', async () => {
+    const mockData = [{ id: 1, description: 'About me' }];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const result = await notionService.getAbout();
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/notion?database=about', {
+      method: 'GET',
+    });
+    expect(result).toEqual(mockData);
+  });
+
+  it('should fetch all data correctly', async () => {
+    const mockProjects = [{ id: 1, title: 'Project 1' }];
+    const mockWork = [{ id: 1, company: 'Company A' }];
+    const mockAbout = [{ id: 1, description: 'About me' }];
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => mockProjects })
+      .mockResolvedValueOnce({ ok: true, json: async () => mockWork })
+      .mockResolvedValueOnce({ ok: true, json: async () => mockAbout });
+
+    const result = await notionService.getAllData();
+
+    expect(result).toEqual({
+      projects: mockProjects,
+      work: mockWork,
+      about: mockAbout,
+    });
+  });
+
+  it('should handle API errors gracefully', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: 'API Error' }),
+    });
+
+    const result = await notionService.getProjects();
+
+    expect(result).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/services/notionService.ts
+++ b/src/services/notionService.ts
@@ -32,36 +32,18 @@ const fetchNotionDatabase = async (databaseType: string): Promise<any[]> => {
   }
 };
 
-// Data is already transformed by serverless function, just pass through
-const transformProjectsData = (data: any[]): any[] => {
-  return data;
-};
-
-// Data is already transformed by serverless function, just pass through
-const transformWorkData = (data: any[]): any[] => {
-  return data;
-};
-
-// Data is already transformed by serverless function, just pass through
-const transformAboutData = (data: any[]): any[] => {
-  return data;
-};
-
 // Main Notion Service class
 class NotionService {
   async getProjects() {
-    const pages = await fetchNotionDatabase("projects");
-    return transformProjectsData(pages);
+    return fetchNotionDatabase("projects");
   }
 
   async getWork() {
-    const pages = await fetchNotionDatabase("work");
-    return transformWorkData(pages);
+    return fetchNotionDatabase("work");
   }
 
   async getAbout() {
-    const pages = await fetchNotionDatabase("about");
-    return transformAboutData(pages);
+    return fetchNotionDatabase("about");
   }
 
   async getAllData() {


### PR DESCRIPTION
## **User description**
Resolves merge conflicts on PR #455 by checking out the PR branch, hard resetting to `main`, and re-applying the intended patch:
- Removed unused `transformProjectsData`, `transformWorkData`, and `transformAboutData` functions from `src/services/notionService.ts`.
- Updated `getProjects()`, `getWork()`, and `getAbout()` in `NotionService` to return `fetchNotionDatabase` results directly.
- Added test coverage in `src/services/__tests__/notionService.test.ts`.

---
*PR created automatically by Jules for task [15490350052880601316](https://jules.google.com/task/15490350052880601316) started by @guitarbeat*

## Summary by Sourcery

Refactor NotionService to directly return data from the Notion API and add tests for its core methods.

Bug Fixes:
- Ensure NotionService methods return empty arrays and log errors when the API response is not OK.

Enhancements:
- Remove unused data transformation helpers from NotionService and simplify getProjects, getWork, and getAbout to delegate directly to the shared fetch helper.

Tests:
- Add unit tests for NotionService methods to verify correct API endpoints, aggregation in getAllData, and graceful handling of API errors.


___

## **CodeAnt-AI Description**
**Simplify Notion data loading and cover it with tests**

### What Changed
- Notion data for projects, work, and about now returns directly from the shared fetch flow, with no extra pass-through step.
- Added tests that verify each section loads from the right endpoint, all content can be loaded together, and failed requests return an empty list instead of breaking the page.
- Error handling now keeps the app from crashing when the Notion API does not respond successfully.

### Impact
`✅ Fewer content-loading failures`
`✅ Clearer fallback behavior when Notion requests fail`
`✅ Safer homepage and portfolio data loading`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
