### PR TITLE
fix(header): resolve missing profile3 image for Vite build

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,8 @@ personal-website/
 | `assets/images/nu-uh-uh.webp` | Image | WebP image asset | None | ✅ Active |
 | `assets/images/profile1-nbg.png` | Image | Profile image 1 (no background) | None | ✅ Active |
 | `assets/images/profile2-nbg.png` | Image | Profile image 2 (no background) | None | ✅ Active |
-| `assets/images/profile3-nbg.png` | Image | Profile image 3 (no background) | None | ✅ Active |
+| `assets/images/profile1v2-nbg.png` | Image | Alternate profile 1 / third header cycling image | None | ✅ Active |
 | `assets/images/profile4.png` | Image | Profile image 4 | None | ✅ Active |
-| `assets/images/profile5.png` | Image | Profile image 5 | None | ✅ Active |
 | `assets/images/shell.png` | Image | Shell/terminal image | None | ✅ Active |
 
 ## Analysis Tools

--- a/src/components/content/Header/Header.tsx
+++ b/src/components/content/Header/Header.tsx
@@ -6,7 +6,7 @@ import cvFile from "../../../assets/documents/cv.pdf";
 // Asset imports
 import profile1 from "../../../assets/images/profile1-nbg.png";
 import profile2 from "../../../assets/images/profile2-nbg.png";
-import profile3 from "../../../assets/images/profile3-nbg.png";
+import profile3 from "../../../assets/images/profile1v2-nbg.png";
 import profile4 from "../../../assets/images/profile4.png";
 
 // Local imports


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vercel’s `vite build` failed with `UNRESOLVED_IMPORT` for `src/assets/images/profile3-nbg.png` because that file is not in the repository (no committed asset at that path).

## Changes

- Point the third header cycling image import at the existing `profile1v2-nbg.png` asset instead.
- Update the README static assets table to match tracked files (replace the stale `profile3-nbg.png` row and remove the non-existent `profile5.png` row).

## Verification

Local CI tooling (pnpm / Node) was not available in this environment, so `pnpm run build:dev` was not executed here. Please confirm with your usual `pnpm run build:dev` or redeploy on Vercel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1471e07b-3e09-4987-8466-80b0436a3ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1471e07b-3e09-4987-8466-80b0436a3ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Fix header profile image reference and align documentation with existing assets.

Bug Fixes:
- Resolve missing third header profile image by referencing the existing profile1v2-nbg asset.

Documentation:
- Update README static assets table to reflect the actual tracked profile image files and remove non-existent entries.