### PR TITLE
🔒 Fix API CORS cache vulnerability and restrict wildcard domain matching

### DIFF
--- a/src/server/apiCors.js
+++ b/src/server/apiCors.js
@@ -4,7 +4,7 @@ const PRODUCTION_WHITELIST = [
   "https://pixel-pal-follow.lovable.app",
 ];
 
-let corsConfigCache = null;
+const corsConfigCache = new Map();
 
 function buildCorsConfig(env = process.env) {
   const envOrigins = env.ALLOWED_ORIGINS;
@@ -35,7 +35,7 @@ function buildCorsConfig(env = process.env) {
   for (const part of parts) {
     if (part.includes("*")) {
       const escaped = part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regexStr = `^${escaped.replace(/\\\*/g, ".*")}$`;
+      const regexStr = `^${escaped.replace(/\\\*/g, "[a-zA-Z0-9-]+")}$`;
       regexes.push(new RegExp(regexStr));
     } else {
       exact.push(part);
@@ -50,19 +50,23 @@ export function isOriginAllowed(origin, env = process.env) {
     return false;
   }
 
-  if (!corsConfigCache) {
-    corsConfigCache = buildCorsConfig(env);
+  const envOrigins = env.ALLOWED_ORIGINS || "default";
+
+  if (!corsConfigCache.has(envOrigins)) {
+    corsConfigCache.set(envOrigins, buildCorsConfig(env));
   }
 
-  if (corsConfigCache.allowAll) {
+  const config = corsConfigCache.get(envOrigins);
+
+  if (config.allowAll) {
     return true;
   }
 
-  if (corsConfigCache.exact.includes(origin)) {
+  if (config.exact.includes(origin)) {
     return true;
   }
 
-  return corsConfigCache.regexes.some((regex) => regex.test(origin));
+  return config.regexes.some((regex) => regex.test(origin));
 }
 
 export function applyCors(

--- a/src/server/apiCors.test.js
+++ b/src/server/apiCors.test.js
@@ -1,0 +1,43 @@
+import { isOriginAllowed } from "./apiCors.js";
+
+describe("apiCors", () => {
+  it("should block empty origins", () => {
+    expect(isOriginAllowed("", { ALLOWED_ORIGINS: "https://example.com" })).toBe(false);
+    expect(isOriginAllowed(null, { ALLOWED_ORIGINS: "https://example.com" })).toBe(false);
+    expect(isOriginAllowed(undefined, { ALLOWED_ORIGINS: "https://example.com" })).toBe(false);
+  });
+
+  it("should evaluate global allow wildcard correctly", () => {
+    expect(isOriginAllowed("https://anything.com", { ALLOWED_ORIGINS: "*" })).toBe(true);
+    expect(isOriginAllowed("http://localhost:3000", { ALLOWED_ORIGINS: "*" })).toBe(true);
+  });
+
+  it("should match exact origins", () => {
+    const env = { ALLOWED_ORIGINS: "https://example.com,https://test.com" };
+    expect(isOriginAllowed("https://example.com", env)).toBe(true);
+    expect(isOriginAllowed("https://test.com", env)).toBe(true);
+    expect(isOriginAllowed("https://other.com", env)).toBe(false);
+  });
+
+  it("should match wildcard domain origins securely", () => {
+    const env = { ALLOWED_ORIGINS: "https://*.example.com" };
+    expect(isOriginAllowed("https://app.example.com", env)).toBe(true);
+    expect(isOriginAllowed("https://test.example.com", env)).toBe(true);
+    // Should NOT match evil domain extensions or paths
+    expect(isOriginAllowed("https://example.com.evil.com", env)).toBe(false);
+    expect(isOriginAllowed("https://evil.example.com.evil.com", env)).toBe(false);
+  });
+
+  it("should correctly cache per environment string rather than globally", () => {
+    const env1 = { ALLOWED_ORIGINS: "https://env1.com" };
+    const env2 = { ALLOWED_ORIGINS: "https://env2.com" };
+
+    // Initially call env1
+    expect(isOriginAllowed("https://env1.com", env1)).toBe(true);
+    expect(isOriginAllowed("https://env2.com", env1)).toBe(false);
+
+    // Now call env2 - it should not be polluted by env1's cache
+    expect(isOriginAllowed("https://env2.com", env2)).toBe(true);
+    expect(isOriginAllowed("https://env1.com", env2)).toBe(false);
+  });
+});


### PR DESCRIPTION
🎯 What:
- Changed the corsConfigCache in src/server/apiCors.js from a global cache variable to a Map indexed by env.ALLOWED_ORIGINS.
- Updated the regex generation for wildcard allowed origins to convert * to [a-zA-Z0-9-]+ instead of .*.
- Added a full test suite in src/server/apiCors.test.js to verify caching correctness and domain matching safety.

⚠️ Risk:
- Global caching of corsConfigCache could cache the environment variable state, meaning if the code was called sequentially under different environments or contexts with different variables, the initial state would bleed over into the second request, potentially allowing unauthorized origins or blocking authorized ones.
- Expanding wildcard * to .* is overly permissive, potentially allowing origin reflection bypasses.

🛡️ Solution:
- Cache CORS configuration individually per environment definition.
- Use [a-zA-Z0-9-]+ to strictly evaluate subdomain mapping and prohibit dots, limiting origin bypasses via domain extensions or trailing paths.

---
*PR created automatically by Jules for task [4250824012480581451](https://jules.google.com/task/4250824012480581451) started by @guitarbeat*