### PR TITLE
🧹 [Code Health] Remove duplicate AboutItem interface and clean up legacy Sheets imports

### DIFF
--- a/src/components/content/About/About.tsx
+++ b/src/components/content/About/About.tsx
@@ -1,9 +1,7 @@
 // About section content component for the personal website.
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-// import { processAboutData } from "../../../utils/googleSheetsUtils";
 import shell from "../../../assets/images/shell.png";
-// import { withGoogleSheets } from "react-db-google-sheets";
 import { useNotion } from "../../../contexts/NotionContext";
 import { cn } from "../../../utils/commonUtils";
 

--- a/src/components/content/Projects/Projects.tsx
+++ b/src/components/content/Projects/Projects.tsx
@@ -4,7 +4,6 @@ import { useNotion } from "../../../contexts/NotionContext";
 import type { ProjectItem } from "../../../types/content";
 import { generateTagColors } from "../../../utils/colorUtils";
 import { clamp, cn } from "../../../utils/commonUtils";
-// import { processProjectsData } from "../../../utils/googleSheetsUtils";
 import PixelCanvas from "../../effects/PixelCanvas/PixelCanvas";
 
 const DEFAULT_PROJECT_EFFECT = {

--- a/src/components/content/Work/Work.tsx
+++ b/src/components/content/Work/Work.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 // import { withGoogleSheets } from "react-db-google-sheets";
 import { useNotion } from "../../../contexts/NotionContext";
 import { cn } from "../../../utils/commonUtils";
-// import { processWorkData } from "../../../utils/googleSheetsUtils";
 import PixelCanvas from "../../effects/PixelCanvas/PixelCanvas";
 
 interface Job {

--- a/src/utils/googleSheetsUtils.ts
+++ b/src/utils/googleSheetsUtils.ts
@@ -1,9 +1,6 @@
 // Utility functions for processing data from Google Sheets.
 
-export interface AboutItem {
-  category: string;
-  description: string;
-}
+import type { AboutItem } from "../types/content";
 
 export interface ProjectItem {
   title: string;


### PR DESCRIPTION
🎯 **What:** Removed duplicate `AboutItem` interface in `src/utils/googleSheetsUtils.ts` by importing it from `src/types/content.ts`. Also cleaned up legacy commented-out imports of `googleSheetsUtils` and `react-db-google-sheets` in several components (`About.tsx`, `Projects.tsx`, `Work.tsx`).

💡 **Why:** This reduces code duplication and adheres to the new codebase rules that deprecate the legacy Google Sheets integration. Removing dead code and consolidating types improves readability and maintainability.

✅ **Verification:** Verified by running `pnpm run lint`, `pnpm test`, and `pnpm exec tsc --noEmit`. All tests passed, ensuring no functionality was broken.

✨ **Result:** Cleaned up unused legacy code and standardized type imports.

---
*PR created automatically by Jules for task [5901507428509138490](https://jules.google.com/task/5901507428509138490) started by @guitarbeat*