### PR TITLE
🧹 [code health] Avoid any type in parsePrintfulProduct parameter

### DIFF
--- a/src/utils/shopUtils.ts
+++ b/src/utils/shopUtils.ts
@@ -46,8 +46,7 @@ export interface ParsedProduct {
 /**
  * Parses Printful product data to extract key information
  */
-// biome-ignore lint/suspicious/noExplicitAny: External API data structure is complex
-export const parsePrintfulProduct = (product: any): ParsedProduct => {
+export const parsePrintfulProduct = (product: unknown): ParsedProduct => {
   // Input validation
   if (!product || typeof product !== "object") {
     console.warn("parsePrintfulProduct: Invalid product object provided");
@@ -59,12 +58,13 @@ export const parsePrintfulProduct = (product: any): ParsedProduct => {
     };
   }
 
-  const syncProduct = product.sync_product || null;
-  const syncVariants = product.sync_variants || [];
-  const firstVariant = Array.isArray(syncVariants)
-    ? syncVariants[0] || null
-    : null;
-  const price = Number(firstVariant?.retail_price) || 0;
+  const p = product as Record<string, unknown>;
+  const syncProduct = p.sync_product || null;
+  const syncVariants = Array.isArray(p.sync_variants) ? p.sync_variants : [];
+  const firstVariant = syncVariants.length > 0 ? syncVariants[0] : null;
+  const price = firstVariant && typeof firstVariant === 'object' && 'retail_price' in firstVariant
+    ? Number((firstVariant as Record<string, unknown>).retail_price) || 0
+    : 0;
 
   return {
     syncProduct,


### PR DESCRIPTION
🎯 **What:** Replaced the `any` type with `unknown` for the `product` parameter in the `parsePrintfulProduct` function in `src/utils/shopUtils.ts`. Added a type cast `Record<string, unknown>` to safely access object properties while satisfying TypeScript checks without relying on `any`.
💡 **Why:** Using `any` bypasses TypeScript's type checking, resulting in a loss of type safety and potentially hiding bugs. Enforcing `unknown` provides better code health, prompting safe type checking or casting before use.
✅ **Verification:** Verified by running `pnpm run lint src/utils/shopUtils.ts`, `pnpm test src/utils/__tests__/shopUtils.test.ts`, and `pnpm exec tsc --noEmit`. No regressions found, all tests and types pass.
✨ **Result:** Improved type safety and codebase maintainability without changing runtime behavior.

---
*PR created automatically by Jules for task [6814621634947458273](https://jules.google.com/task/6814621634947458273) started by @guitarbeat*