### PR TITLE
🧪 add tests for useVFXEffect error paths and lifecycle

### DIFF
--- a/src/hooks/__tests__/useVFXEffect.importError.test.ts
+++ b/src/hooks/__tests__/useVFXEffect.importError.test.ts
@@ -1,0 +1,40 @@
+import { renderHook, act } from '@testing-library/react';
+import { useVFXEffect } from '../useVFXEffect';
+
+const originalWarn = console.warn;
+
+describe('useVFXEffect import error', () => {
+  beforeEach(() => {
+    console.warn = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    jest.restoreAllMocks();
+  });
+
+  it('handles VFX import failure gracefully', async () => {
+    // By not mocking the import, Jest will throw MODULE_NOT_FOUND natively
+    renderHook(() => useVFXEffect({}));
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "Failed to load VFX core:",
+      expect.objectContaining({ message: expect.stringContaining("Cannot find module") })
+    );
+  });
+
+  it('does not attempt to load VFX if disabled', async () => {
+    renderHook(() => useVFXEffect({ enabled: false }));
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useVFXEffect.test.ts
+++ b/src/hooks/__tests__/useVFXEffect.test.ts
@@ -1,0 +1,133 @@
+import { renderHook, act } from '@testing-library/react';
+import { useVFXEffect } from '../useVFXEffect';
+
+const mockAdd = jest.fn();
+const mockRemove = jest.fn();
+
+// Mock the dynamic import of the VFX library
+jest.mock('https://esm.sh/@vfx-js/core', () => {
+  return {
+    VFX: class MockVFX {
+      add = mockAdd;
+      remove = mockRemove;
+    }
+  };
+}, { virtual: true });
+
+const originalWarn = console.warn;
+
+describe('useVFXEffect', () => {
+  beforeEach(() => {
+    console.warn = jest.fn();
+    mockAdd.mockClear();
+    mockRemove.mockClear();
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+
+  it('initializes VFX instance successfully', async () => {
+    renderHook(() => useVFXEffect({}));
+
+    // Wait for dynamic import
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('handles VFX application error gracefully', async () => {
+    mockAdd.mockImplementation(() => {
+      throw new Error("Simulated add error");
+    });
+
+    const activeElement = document.createElement('div');
+
+    // Initial render
+    const { rerender } = renderHook(
+      (props) => useVFXEffect(props),
+      { initialProps: { activeElement: null as HTMLElement | null } }
+    );
+
+    // Wait for init
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+
+    // Update activeElement
+    rerender({ activeElement });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "VFX application error:",
+      expect.any(Error)
+    );
+  });
+
+  it('handles VFX removal error gracefully', async () => {
+    mockRemove.mockImplementation(() => {
+      throw new Error("Simulated remove error");
+    });
+
+    const element1 = document.createElement('div');
+    const element2 = document.createElement('div');
+
+    // Initial render with element1
+    const { rerender } = renderHook(
+      (props) => useVFXEffect(props),
+      { initialProps: { activeElement: element1 as HTMLElement | null } }
+    );
+
+    // Wait for init and application to element1
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+
+    // Re-render to ensure previousActiveRef is updated
+    rerender({ activeElement: element1 });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+
+    // Change to element2 to trigger removal on element1
+    rerender({ activeElement: element2 });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "VFX removal error:",
+      expect.any(Error)
+    );
+  });
+
+  it('cleans up effects silently on unmount', async () => {
+    mockRemove.mockImplementation(() => {
+      throw new Error("Simulated cleanup error");
+    });
+
+    const activeElement = document.createElement('div');
+
+    const { unmount, rerender } = renderHook(
+      (props) => useVFXEffect(props),
+      { initialProps: { activeElement: activeElement as HTMLElement | null } }
+    );
+
+    // Wait for init
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+
+    // Re-render to ensure element is registered in `previousActiveRef.current`
+    rerender({ activeElement });
+
+    // Unmount triggers cleanup
+    unmount();
+
+    // The catch block in cleanup has an empty body with a comment // Silently handle cleanup errors
+    // So console.warn should not be called
+    expect(console.warn).not.toHaveBeenCalledWith(
+      "VFX removal error:",
+      expect.any(Error)
+    );
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added tests to cover the previously untested error paths and lifecycle boundaries in `useVFXEffect.ts`.
📊 **Coverage:** Covered successful initialization, graceful handling of dynamic import failures (simulated via JSDOM native MODULE_NOT_FOUND throws), application errors when adding an effect, removal errors when swapping active elements, and silent unmount cleanup.
✨ **Result:** Enhanced test coverage and reliability for the custom hook that manages the visual shader effects on navigation links.

---
*PR created automatically by Jules for task [16488465588945737615](https://jules.google.com/task/16488465588945737615) started by @guitarbeat*