### PR TITLE
🧹 [Code Health] Remove duplicate WorkItem interface from googleSheetsUtils.ts

### DIFF
--- a/src/utils/googleSheetsUtils.ts
+++ b/src/utils/googleSheetsUtils.ts
@@ -1,3 +1,5 @@
+import type { WorkItem } from "../types/content";
+
 // Utility functions for processing data from Google Sheets.
 
 export interface AboutItem {
@@ -13,16 +15,6 @@ export interface ProjectItem {
   link: string;
   content: string;
   image: string;
-}
-
-export interface WorkItem {
-  title: string;
-  company: string;
-  place: string;
-  from: string;
-  to: string;
-  description: string;
-  slug: string;
 }
 
 export const processAboutData = (data: Record<string, string>[]): AboutItem[] =>


### PR DESCRIPTION
🎯 **What:** Removed the duplicate `WorkItem` interface definition from `src/utils/googleSheetsUtils.ts` and updated the file to import the single source of truth from `src/types/content.ts`.

💡 **Why:** Having duplicate interfaces in the codebase makes it harder to maintain and could lead to bugs if the interfaces fall out of sync in the future. By using centrally defined types, we improve the maintainability and readability of the codebase.

✅ **Verification:** Verified the code builds properly via `tsc --noEmit`, ran formatting and linting via `pnpm run lint`, and ran unit tests via `pnpm test` ensuring the utility processing logic works as expected.

✨ **Result:** A cleaner utility file that relies on our central types without changing any data structure or behavior.

---
*PR created automatically by Jules for task [7971621961002270751](https://jules.google.com/task/7971621961002270751) started by @guitarbeat*