### PR TITLE
🧹 [Code Health] Remove commented out code in Moire component

### DIFF
--- a/src/components/effects/Moire/Moire.tsx
+++ b/src/components/effects/Moire/Moire.tsx
@@ -19,7 +19,6 @@ function _Magic(containerEl: Element | null) {
   let width: number;
   let height: number;
   let wWidth: number;
-  // let wHeight; // Remove this line
   let mouse: InstanceType<typeof Vec2>;
   let mouseOver = false;
 
@@ -266,7 +265,6 @@ function _Magic(containerEl: Element | null) {
     camera.perspective({ aspect: width / height });
     const wSize = getWorldSize(camera);
     wWidth = wSize[0];
-    // wHeight = wSize[1]; // Remove this line
     if (points) {
       initPointsMesh();
     }


### PR DESCRIPTION
🎯 **What:** Removed commented out variable declaration `let wHeight;` and its assignment `wHeight = wSize[1];` in the Moire component.
💡 **Why:** Dead code clutters the codebase and reduces readability. The variable `wHeight` was clearly commented out and was not being used anywhere in the codebase.
✅ **Verification:** Ran `pnpm run lint`, `pnpm test`, and `pnpm exec tsc --noEmit` locally, which all passed successfully, verifying that no functional code was affected.
✨ **Result:** A cleaner and more readable component file without commented out legacy code.

---
*PR created automatically by Jules for task [2244442394546469167](https://jules.google.com/task/2244442394546469167) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Eliminate legacy commented-out variable declarations in the Moire component to reduce clutter.