### PR TITLE
🧹 chore: remove obsolete react-db-google-sheets imports

### DIFF
--- a/src/components/content/Projects/Projects.tsx
+++ b/src/components/content/Projects/Projects.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-// import { withGoogleSheets } from "react-db-google-sheets";
 import { useNotion } from "../../../contexts/NotionContext";
 import type { ProjectItem } from "../../../types/content";
 import { generateTagColors } from "../../../utils/colorUtils";

--- a/src/components/content/Work/Work.tsx
+++ b/src/components/content/Work/Work.tsx
@@ -1,7 +1,6 @@
 import moment from "moment";
 // Import required libraries and components
 import React, { useCallback, useEffect, useRef, useState } from "react";
-// import { withGoogleSheets } from "react-db-google-sheets";
 import { useNotion } from "../../../contexts/NotionContext";
 import { cn } from "../../../utils/commonUtils";
 import PixelCanvas from "../../effects/PixelCanvas/PixelCanvas";


### PR DESCRIPTION
🎯 **What:** Removed commented-out `react-db-google-sheets` imports from `src/components/content/Work/Work.tsx` and `src/components/content/Projects/Projects.tsx`.
💡 **Why:** Dead, commented-out code degrades readability. The legacy Google Sheets integration has been replaced by Notion, so these comments were completely obsolete.
✅ **Verification:** Ran `pnpm test`, `pnpm run lint`, and `pnpm exec tsc --noEmit` locally. All checks passed successfully (warnings in Matrix tests are preexisting). Reviewed the diff to ensure no active code was affected.
✨ **Result:** Improved code cleanliness and readability by removing obsolete artifacts.

---
*PR created automatically by Jules for task [4066260525897651267](https://jules.google.com/task/4066260525897651267) started by @guitarbeat*

## Summary by Sourcery

Chores:
- Remove commented-out react-db-google-sheets imports from Projects and Work content components to reduce dead code.