### PR TITLE
🔒 Fix timing attack vulnerability in timingSafeCompare

### DIFF
--- a/src/server/notionContent.js
+++ b/src/server/notionContent.js
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+
 const NOTION_API_BASE = "https://api.notion.com/v1";
 const NOTION_VERSION = "2022-06-28";
 
@@ -313,8 +314,12 @@ function transformProjectsData(results, projectContentByPageId = new Map()) {
           props.content?.rich_text ||
           props.Description?.rich_text ||
           [],
-      ) || projectContentByPageId.get(page.id) || "";
-    const rawHook = extractRichText(props.Hook?.rich_text || props.hook?.rich_text || []);
+      ) ||
+      projectContentByPageId.get(page.id) ||
+      "";
+    const rawHook = extractRichText(
+      props.Hook?.rich_text || props.hook?.rich_text || [],
+    );
 
     return {
       title: titleText,
@@ -339,8 +344,7 @@ function transformProjectsData(results, projectContentByPageId = new Map()) {
       keywords: extractMultiSelectNames(
         props.Keyword?.multi_select || props.keyword?.multi_select || [],
       ),
-      published:
-        extractCheckboxValue(props.Published, props.published) ?? true,
+      published: extractCheckboxValue(props.Published, props.published) ?? true,
       sortOrder: extractNumberValue(
         props["Sort Order"],
         props.SortOrder,
@@ -908,7 +912,9 @@ async function fetchProjectContentByPageId({
       });
       const pageContent = blocks
         .map(extractBlockPlainText)
-        .filter((blockText) => typeof blockText === "string" && blockText.length)
+        .filter(
+          (blockText) => typeof blockText === "string" && blockText.length,
+        )
         .join("\n\n");
 
       return [page.id, pageContent];
@@ -1016,7 +1022,7 @@ export async function queryNotionDatabase({
         )
       : databaseType === "work"
         ? prepareWorkForPublicDisplay(transformWorkData(rawResults))
-      : getDatasetTransformer(databaseType)(rawResults);
+        : getDatasetTransformer(databaseType)(rawResults);
 
   return validateDatasetRecords(databaseType, records);
 }
@@ -1367,21 +1373,15 @@ export async function getHealthSummary({
   };
 }
 
-
 function timingSafeCompare(a, b) {
-  if (typeof a !== 'string' || typeof b !== 'string') {
+  if (typeof a !== "string" || typeof b !== "string") {
     return false;
   }
 
-  const aBuffer = Buffer.from(a);
-  const bBuffer = Buffer.from(b);
+  const aHash = crypto.createHash("sha256").update(a).digest();
+  const bHash = crypto.createHash("sha256").update(b).digest();
 
-  if (aBuffer.length !== bBuffer.length) {
-    crypto.timingSafeEqual(aBuffer, aBuffer);
-    return false;
-  }
-
-  return crypto.timingSafeEqual(aBuffer, bBuffer);
+  return crypto.timingSafeEqual(aHash, bHash);
 }
 
 export function isAuthorizedCronRequest(req, env = process.env) {
@@ -1394,7 +1394,10 @@ export function isAuthorizedCronRequest(req, env = process.env) {
   const authorization = req.headers.authorization;
   const headerSecret = req.headers["x-cron-secret"];
 
-  const isBearerValid = timingSafeCompare(authorization || "", `Bearer ${secret}`);
+  const isBearerValid = timingSafeCompare(
+    authorization || "",
+    `Bearer ${secret}`,
+  );
   const isHeaderValid = timingSafeCompare(headerSecret || "", secret);
 
   return isBearerValid || isHeaderValid;
@@ -1419,10 +1422,10 @@ export function createErrorPayload(error) {
   }
 
   return {
-      error: {
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Internal server error",
-        failureType: "internal_server_error",
-      },
-    };
+    error: {
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Internal server error",
+      failureType: "internal_server_error",
+    },
+  };
 }


### PR DESCRIPTION
🎯 What:
Fixed a timing attack vulnerability in `timingSafeCompare` within `src/server/notionContent.js`.

⚠️ Risk:
The previous implementation performed an early return if the lengths of the two strings did not match. Although it ran a dummy comparison (`crypto.timingSafeEqual(aBuffer, aBuffer)`) before returning to mitigate timing differences, this still implicitly leaked the exact length of the expected secret string. An attacker could exploit this length leak to narrow down the space of possible secrets, increasing the feasibility of an attack, specifically against the cron job endpoint auth checks.

🛡️ Solution:
Modified the function to calculate the SHA-256 hash of both strings before running `crypto.timingSafeEqual` on the resulting hashes. Since SHA-256 hashes always have a constant length (32 bytes), `crypto.timingSafeEqual` never performs early length-based exits. The hashing duration depends only on the length of the attacker's input, leaking no information about the secret length or its contents.

---
*PR created automatically by Jules for task [9369178793993208612](https://jules.google.com/task/9369178793993208612) started by @guitarbeat*

## Summary by Sourcery

Mitigate timing attack risk in cron auth secret comparison and clean up minor formatting in Notion content server module.

Bug Fixes:
- Harden timingSafeCompare by hashing inputs and comparing constant-length hashes to prevent length-based timing leaks in cron auth checks.

Enhancements:
- Minor code style and formatting adjustments in Notion content transformation, project content fetching, and error payload helpers.