### PR TITLE
fix: trigger matrix hack action via space/enter keyboard interaction without mobile touch double-firing

### DIFF
--- a/src/components/effects/Matrix/Matrix.tsx
+++ b/src/components/effects/Matrix/Matrix.tsx
@@ -683,17 +683,22 @@ const Matrix = ({ isVisible, onSuccess, onMatrixReady }: MatrixProps) => {
   const successTelemetry = successTelemetryRef.current;
   const showConsoleCursor = !isHackingComplete;
 
-  const handleViewportEngage = useCallback(() => {
-    if (isHackingComplete) {
-      return;
-    }
+  const handleViewportEngage = useCallback(
+    (e?: React.SyntheticEvent) => {
+      e?.preventDefault();
 
-    // Trigger hack action (supports "tap to hack")
-    handleManualHackTrigger();
+      if (isHackingComplete) {
+        return;
+      }
 
-    // Also try to focus for keyboard users, but don't blocking tap flow
-    focusHackInput();
-  }, [focusHackInput, isHackingComplete, handleManualHackTrigger]);
+      // Trigger hack action (supports "tap to hack")
+      handleManualHackTrigger();
+
+      // Also try to focus for keyboard users, but don't blocking tap flow
+      focusHackInput();
+    },
+    [focusHackInput, isHackingComplete, handleManualHackTrigger],
+  );
 
   // * Handle container clicks
   const handleContainerClick = useCallback(
@@ -1174,8 +1179,9 @@ const Matrix = ({ isVisible, onSuccess, onMatrixReady }: MatrixProps) => {
                 role="button"
                 tabIndex={0}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ")
-                    handleViewportEngage();
+                  if (e.key === "Enter" || e.key === " ") {
+                    handleViewportEngage(e);
+                  }
                 }}
                 onMouseDown={handleViewportEngage}
                 onTouchStart={handleViewportEngage}


### PR DESCRIPTION
- Modified `handleViewportEngage` in `Matrix.tsx` to optionally accept a React synthetic event.
- Added `e?.preventDefault()` to `handleViewportEngage` to stop double-firing on mobile devices (where `touchstart` is often followed by a synthesized `mousedown`) and to prevent the default page scrolling behavior when pressing "Space".
- Updated the `onKeyDown` handler for the `.hack-input-viewport` to pass the `KeyboardEvent` to `handleViewportEngage`.
- `onMouseDown` and `onTouchStart` inherently pass the event to the bound handler.
- Verified test suite for Matrix continues to pass successfully.

---
*PR created automatically by Jules for task [12971958566492197926](https://jules.google.com/task/12971958566492197926) started by @guitarbeat*

## Summary by Sourcery

Prevent duplicate Matrix viewport engagement on mobile and align keyboard-triggered hack actions with pointer interactions.

Bug Fixes:
- Ensure Matrix viewport engagement does not double-trigger on mobile due to combined touch and mouse events.
- Prevent default scrolling when activating the Matrix viewport with the Space key while still triggering the hack action.