### PR TITLE
🔒 Fix permissive CORS wildcard regex generation

### DIFF
--- a/src/server/apiCors.js
+++ b/src/server/apiCors.js
@@ -34,9 +34,21 @@ function buildCorsConfig(env = process.env) {
 
   for (const part of parts) {
     if (part.includes("*")) {
-      const escaped = part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regexStr = `^${escaped.replace(/\\\*/g, "[a-zA-Z0-9-]+")}$`;
-      regexes.push(new RegExp(regexStr));
+      // Security Fix: Prevent partial wildcard matching like https://*-domain.com
+      // Only allow wildcards as full subdomains, e.g., https://*.example.com
+      try {
+        const _url = new URL(part.replace(/\*/g, 'test'));
+        const originalHostParts = part.split('://')[1].split('/')[0].split('.');
+        const isValidWildcard = originalHostParts.every(p => !p.includes('*') || p === '*');
+
+        if (isValidWildcard) {
+          const escaped = part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const regexStr = `^${escaped.replace(/\\\*/g, "[a-zA-Z0-9-]+")}$`;
+          regexes.push(new RegExp(regexStr));
+        }
+      } catch (_e) {
+        // Invalid URL structure, ignore
+      }
     } else {
       exact.push(part);
     }

--- a/src/server/apiCors.test.js
+++ b/src/server/apiCors.test.js
@@ -28,6 +28,15 @@ describe("apiCors", () => {
     expect(isOriginAllowed("https://evil.example.com.evil.com", env)).toBe(false);
   });
 
+  it("should block invalid wildcard placements to prevent permissive matching", () => {
+    // Should NOT allow partial subdomains like *-domain.com
+    const envPrefix = { ALLOWED_ORIGINS: "https://*-domain.com" };
+    expect(isOriginAllowed("https://attacker-domain.com", envPrefix)).toBe(false);
+
+    const envSuffix = { ALLOWED_ORIGINS: "https://domain-*.com" };
+    expect(isOriginAllowed("https://domain-attacker.com", envSuffix)).toBe(false);
+  });
+
   it("should correctly cache per environment string rather than globally", () => {
     const env1 = { ALLOWED_ORIGINS: "https://env1.com" };
     const env2 = { ALLOWED_ORIGINS: "https://env2.com" };


### PR DESCRIPTION
🎯 **What:** The `isOriginAllowed` function allowed partial wildcard matches (e.g., `https://*-domain.com`) by merely escaping user input without verifying whether the wildcard was utilized exclusively as an entire standalone subdomain.

⚠️ **Risk:** An attacker could craft a subdomain imitating the whitelist (e.g. `https://attacker-domain.com`) to bypass Cross-Origin Resource Sharing restrictions, leading to potential unauthorized API requests and data exfiltration from authenticated users.

🛡️ **Solution:** Implemented structural validation using the native URL parser to ensure that any wildcard (`*`) represents a full standalone subdomain portion. Modified regex string generation and updated the testing suite to enforce explicit blocks on invalid partial subdomain configurations.

---
*PR created automatically by Jules for task [14420706051167987206](https://jules.google.com/task/14420706051167987206) started by @guitarbeat*

## Summary by Sourcery

Harden CORS origin validation by rejecting unsafe wildcard configurations and updating coverage to prevent permissive matches.

Bug Fixes:
- Ensure CORS wildcard origins only match full subdomains and no longer permit partial wildcard patterns that can be abused to bypass origin checks.

Tests:
- Add regression tests to verify that invalid wildcard origin patterns such as *-domain.com and domain-*.com are rejected.