### PR TITLE
chore: remove Google Sheets API keys from Vite env config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -166,7 +166,9 @@ export default defineConfig(({ mode }) => {
           process.env.REACT_APP_ENABLE_VERCEL_ANALYTICS ||
           "",
       ),
-      // Security Fix: Google Sheets API keys removed to prevent client-side exposure
+      // Security Fix: Google Sheets API keys and Printful API keys are initialized to empty strings to prevent client-side exposure
+      "process.env.REACT_APP_GOOGLE_SHEETS_API_KEY": JSON.stringify(""),
+      "process.env.REACT_APP_GOOGLE_SHEETS_DOC_ID": JSON.stringify(""),
       "process.env.REACT_APP_PRINTFUL_API_KEY": JSON.stringify(""),
       "process.env.REACT_APP_PRINTFUL_STORE_ID": JSON.stringify(""),
       "process.env.REACT_APP_GIT_COMMIT_HASH": JSON.stringify(""),


### PR DESCRIPTION
Added explicit empty string initialization for Google Sheets API keys (`REACT_APP_GOOGLE_SHEETS_API_KEY` and `REACT_APP_GOOGLE_SHEETS_DOC_ID`) in `vite.config.ts` to prevent client-side exposure. Updated the surrounding comment to properly reflect both Google Sheets and Printful keys being secured.

---
*PR created automatically by Jules for task [17189042976150336659](https://jules.google.com/task/17189042976150336659) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Clarify security-related comment in the Vite config to mention both Google Sheets and Printful API keys being protected.