### PR TITLE
🧪 Added tests for Printful API error handling

### DIFF
--- a/src/utils/__tests__/shopUtils.test.ts
+++ b/src/utils/__tests__/shopUtils.test.ts
@@ -1,4 +1,4 @@
-import { parsePrintfulProduct } from "../shopUtils";
+import { handlePrintfulError, parsePrintfulProduct } from "../shopUtils";
 
 describe("parsePrintfulProduct", () => {
   it("should return default values for null product", () => {
@@ -82,5 +82,102 @@ describe("parsePrintfulProduct", () => {
     const result = parsePrintfulProduct(mockProduct);
 
     expect(result.price).toBe(0);
+  });
+});
+
+describe("handlePrintfulError", () => {
+  const CORS_ERROR_MSG =
+    "CORS Error: Unable to connect to Printful API. Please ensure the development server is running with the correct proxy configuration.";
+
+  it("should return default error for unknown/unhandled error types (like null or undefined)", () => {
+    expect(handlePrintfulError(null)).toBe("API Error: Unknown Error");
+    expect(handlePrintfulError(undefined)).toBe("API Error: Unknown Error");
+    expect(handlePrintfulError(123)).toBe("API Error: Unknown Error");
+  });
+
+  it("should use custom context prefix", () => {
+    expect(handlePrintfulError(null, "Custom Context")).toBe(
+      "Custom Context: Unknown Error",
+    );
+  });
+
+  describe("Error objects", () => {
+    it("should handle Error object without response (falls back to message)", () => {
+      const err = new Error("Something went wrong");
+      expect(handlePrintfulError(err)).toBe(
+        "API Error: undefined - Something went wrong",
+      );
+    });
+
+    it("should handle Error object with response status and statusText", () => {
+      const err = new Error("Request failed") as unknown as Record<
+        string,
+        unknown
+      >;
+      err.response = { status: 404, statusText: "Not Found" };
+      expect(handlePrintfulError(err)).toBe("API Error: 404 - Not Found");
+    });
+
+    it("should handle Error object with response status but no statusText (falls back to err.message)", () => {
+      const err = new Error("Request failed") as unknown as Record<
+        string,
+        unknown
+      >;
+      err.response = { status: 500 };
+      expect(handlePrintfulError(err)).toBe("API Error: 500 - Request failed");
+    });
+
+    it("should handle Error object that triggers CORS error condition by message", () => {
+      const err = new Error("Network Error");
+      expect(handlePrintfulError(err)).toBe(CORS_ERROR_MSG);
+    });
+
+    it("should handle Error object that triggers CORS error condition by code", () => {
+      const err = new Error("Some error") as unknown as Record<string, unknown>;
+      err.code = "ERR_NETWORK";
+      expect(handlePrintfulError(err)).toBe(CORS_ERROR_MSG);
+    });
+  });
+
+  describe("Plain objects", () => {
+    it("should handle plain object with response status and statusText", () => {
+      const err = { response: { status: 401, statusText: "Unauthorized" } };
+      expect(handlePrintfulError(err)).toBe("API Error: 401 - Unauthorized");
+    });
+
+    it("should handle plain object with response status and message", () => {
+      const err = { response: { status: 400 }, message: "Bad Request" };
+      expect(handlePrintfulError(err)).toBe("API Error: 400 - Bad Request");
+    });
+
+    it("should handle plain object with response status but no statusText or message (falls back to Unknown Error)", () => {
+      const err = { response: { status: 403 } };
+      expect(handlePrintfulError(err)).toBe("API Error: 403 - Unknown Error");
+    });
+
+    it("should handle plain object without response but with message", () => {
+      const err = { message: "Some specific error message" };
+      expect(handlePrintfulError(err)).toBe(
+        "API Error: undefined - Some specific error message",
+      );
+    });
+
+    it("should handle plain object that triggers CORS error condition by message", () => {
+      const err = { message: "Network Error" };
+      expect(handlePrintfulError(err)).toBe(CORS_ERROR_MSG);
+    });
+
+    it("should handle plain object that triggers CORS error condition by code", () => {
+      const err = { code: "ERR_NETWORK" };
+      expect(handlePrintfulError(err)).toBe(CORS_ERROR_MSG);
+    });
+  });
+
+  describe("String errors", () => {
+    it("should handle string error", () => {
+      expect(handlePrintfulError("String error message")).toBe(
+        "API Error: undefined - String error message",
+      );
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** Addressed the testing gap for the `handlePrintfulError` function in `src/utils/shopUtils.ts`.
📊 **Coverage:** Added comprehensive tests for standard `Error` objects, custom objects (with/without response), strings, and unknown inputs. It strictly covers edge cases like CORS connection failures based on `err.message` or `err.code` fallback logic.
✨ **Result:** Improved test coverage and reliability for Shop Printful API integrations.

---
*PR created automatically by Jules for task [11950682981945756812](https://jules.google.com/task/11950682981945756812) started by @guitarbeat*

## Summary by Sourcery

Add comprehensive tests for the handlePrintfulError utility covering various error input types and CORS-specific scenarios.

Tests:
- Add unit tests for handlePrintfulError to cover unknown inputs, custom context prefixes, Error instances, plain error objects, and string errors.
- Verify CORS-related error handling based on error message and code for both Error objects and plain objects.