### PR TITLE
🔒 [Security] Fix unauthenticated local proxy vulnerability

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1,5 +1,8 @@
 import { applyCors } from "../src/server/apiCors.js";
-import { createErrorPayload, getHealthSummary } from "../src/server/notionContent.js";
+import {
+  createErrorPayload,
+  getHealthSummary,
+} from "../src/server/notionContent.js";
 
 export default async function handler(req, res) {
   applyCors(req, res, {

--- a/api/notion.js
+++ b/api/notion.js
@@ -24,7 +24,8 @@ export default async function handler(req, res) {
   return res.status(410).json({
     error: {
       code: "ENDPOINT_RETIRED",
-      message: "The /api/notion endpoint has been retired. Use /api/content instead.",
+      message:
+        "The /api/notion endpoint has been retired. Use /api/content instead.",
       failureType: "endpoint_retired",
     },
   });

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -24,7 +24,30 @@ const DATABASE_IDS = {
 };
 
 // Enable CORS for local development
-app.use(cors());
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (
+      !origin ||
+      origin.match(/^https?:\/\/(localhost|127\.0\.0\.1)(:[0-9]+)?$/)
+    ) {
+      callback(null, true);
+    } else {
+      callback(new Error("Not allowed by CORS"));
+    }
+  },
+};
+app.use(cors(corsOptions));
+
+// Restrict to local loopback IPs
+app.use((req, res, next) => {
+  const localIps = ["127.0.0.1", "::1", "::ffff:127.0.0.1"];
+  if (localIps.includes(req.ip) || !req.ip) {
+    next();
+  } else {
+    res.status(403).json({ error: "Forbidden: Local access only" });
+  }
+});
+
 app.use(express.json());
 
 // Health check endpoint
@@ -46,6 +69,15 @@ app.post("/api/notion/database/:databaseType/query", async (req, res) => {
       return res.status(500).json({ error: "Notion token not configured" });
     }
 
+    // Whitelist allowed payload fields to prevent injection
+    const allowedFields = ["filter", "sorts", "page_size", "start_cursor"];
+    const safeBody = {};
+    for (const key of allowedFields) {
+      if (req.body[key] !== undefined) {
+        safeBody[key] = req.body[key];
+      }
+    }
+
     const response = await fetch(
       `${NOTION_API_BASE}/databases/${databaseId}/query`,
       {
@@ -55,7 +87,10 @@ app.post("/api/notion/database/:databaseType/query", async (req, res) => {
           "Notion-Version": NOTION_VERSION,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(req.body),
+        body:
+          Object.keys(safeBody).length > 0
+            ? JSON.stringify(safeBody)
+            : undefined,
       },
     );
 

--- a/src/components/content/Header/Header.tsx
+++ b/src/components/content/Header/Header.tsx
@@ -5,8 +5,8 @@ import React, { useRef, useState } from "react";
 import cvFile from "../../../assets/documents/cv.pdf";
 // Asset imports
 import profile1 from "../../../assets/images/profile1-nbg.png";
-import profile2 from "../../../assets/images/profile2-nbg.png";
 import profile3 from "../../../assets/images/profile1v2-nbg.png";
+import profile2 from "../../../assets/images/profile2-nbg.png";
 import profile4 from "../../../assets/images/profile4.png";
 
 // Local imports
@@ -106,17 +106,17 @@ const HEADER_SECTIONS: {
   items: string[];
   separator?: string;
 }[] = [
-    { type: "name", items: ["Aaron", "Lorenzo", "Woods"] },
-    {
-      type: "roles",
-      items: ["Engineer", "Artist", "Scientist"],
-      separator: " | ",
-    },
-    {
-      type: "title",
-      items: ["Biomedical", "Engineering", "Doctoral", "Student"],
-    },
-  ];
+  { type: "name", items: ["Aaron", "Lorenzo", "Woods"] },
+  {
+    type: "roles",
+    items: ["Engineer", "Artist", "Scientist"],
+    separator: " | ",
+  },
+  {
+    type: "title",
+    items: ["Biomedical", "Engineering", "Doctoral", "Student"],
+  },
+];
 
 const SOCIAL_MEDIA = [
   {

--- a/src/components/content/Projects/Projects.test.tsx
+++ b/src/components/content/Projects/Projects.test.tsx
@@ -137,7 +137,9 @@ describe("Projects", () => {
 
     render(<Projects db={{ projects: MOCK_PROJECTS }} />);
 
-    const projectCard = await screen.findByRole("link", { name: /Project One/i });
+    const projectCard = await screen.findByRole("link", {
+      name: /Project One/i,
+    });
 
     expect(within(projectCard).getByText("React hook")).toBeInTheDocument();
 

--- a/src/components/content/Projects/Projects.tsx
+++ b/src/components/content/Projects/Projects.tsx
@@ -137,7 +137,9 @@ function ProjectCard({
         </div>
         <h3>{title}</h3>
         <p className="projects__card__hook">{hook}</p>
-        <p className={cn("projects__card__detail", isClicked ? "show-text" : "")}>
+        <p
+          className={cn("projects__card__detail", isClicked ? "show-text" : "")}
+        >
           {detail}
         </p>
         {image && <img src={image} className="project-image" alt="Project" />}
@@ -243,7 +245,10 @@ function Projects({ db: propsDb }: ProjectsProps = {}) {
     [allKeywords],
   );
 
-  const activeFiltersSet = useMemo(() => new Set(activeFilters), [activeFilters]);
+  const activeFiltersSet = useMemo(
+    () => new Set(activeFilters),
+    [activeFilters],
+  );
 
   const project_cards = projectsData.map((projectProps, index) => {
     const primaryKeyword = projectProps.keywords[0] || "";

--- a/src/components/content/Work/Work.test.tsx
+++ b/src/components/content/Work/Work.test.tsx
@@ -107,9 +107,9 @@ describe("Work timeline", () => {
       />,
     );
 
-    const headings = Array.from(container.querySelectorAll(".work__item h2")).map(
-      (heading) => heading.textContent,
-    );
+    const headings = Array.from(
+      container.querySelectorAll(".work__item h2"),
+    ).map((heading) => heading.textContent);
 
     expect(headings).toEqual(["Current Role", "Older Role"]);
   });

--- a/src/components/content/Work/Work.tsx
+++ b/src/components/content/Work/Work.tsx
@@ -136,7 +136,6 @@ function TimelineBar({
   );
 }
 
-
 const CARD_EFFECTS = [
   {
     colors: ["#f8fafc", "#f1f5f9", "#cbd5e1"],
@@ -166,7 +165,6 @@ const MemoizedTimelineBar = React.memo(TimelineBar);
 
 interface WorkProps {
   db?: {
-
     work: unknown[];
   };
 }
@@ -318,6 +316,5 @@ function Work({ db: propsDb }: WorkProps = {}) {
     </div>
   );
 }
-
 
 export default Work;

--- a/src/components/effects/Matrix/AuthContext.tsx
+++ b/src/components/effects/Matrix/AuthContext.tsx
@@ -249,8 +249,6 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     [DEVICE_KEYS.DEFAULT]: isUnlocked,
     [DEVICE_KEYS.MOBILE]: isMobileUnlocked,
   } = unlockState;
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Explicit dependency management
   const toolsAccessible = useMemo(() => {
     if (isMobile) {
       return isMobileUnlocked;
@@ -260,7 +258,6 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <AuthContext.Provider
-      // biome-ignore lint/correctness/useExhaustiveDependencies: Explicit dependency management
       value={useMemo(
         () => ({
           isUnlocked,

--- a/src/hooks/__tests__/useVFXEffect.importError.test.ts
+++ b/src/hooks/__tests__/useVFXEffect.importError.test.ts
@@ -1,9 +1,9 @@
-import { renderHook, act } from '@testing-library/react';
-import { useVFXEffect } from '../useVFXEffect';
+import { act, renderHook } from "@testing-library/react";
+import { useVFXEffect } from "../useVFXEffect";
 
 const originalWarn = console.warn;
 
-describe('useVFXEffect import error', () => {
+describe("useVFXEffect import error", () => {
   beforeEach(() => {
     console.warn = jest.fn();
     jest.clearAllMocks();
@@ -14,25 +14,27 @@ describe('useVFXEffect import error', () => {
     jest.restoreAllMocks();
   });
 
-  it('handles VFX import failure gracefully', async () => {
+  it("handles VFX import failure gracefully", async () => {
     // By not mocking the import, Jest will throw MODULE_NOT_FOUND natively
     renderHook(() => useVFXEffect({}));
 
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
     expect(console.warn).toHaveBeenCalledWith(
       "Failed to load VFX core:",
-      expect.objectContaining({ message: expect.stringContaining("Cannot find module") })
+      expect.objectContaining({
+        message: expect.stringContaining("Cannot find module"),
+      }),
     );
   });
 
-  it('does not attempt to load VFX if disabled', async () => {
+  it("does not attempt to load VFX if disabled", async () => {
     renderHook(() => useVFXEffect({ enabled: false }));
 
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
     expect(console.warn).not.toHaveBeenCalled();

--- a/src/hooks/__tests__/useVFXEffect.test.ts
+++ b/src/hooks/__tests__/useVFXEffect.test.ts
@@ -1,22 +1,26 @@
-import { renderHook, act } from '@testing-library/react';
-import { useVFXEffect } from '../useVFXEffect';
+import { act, renderHook } from "@testing-library/react";
+import { useVFXEffect } from "../useVFXEffect";
 
 const mockAdd = jest.fn();
 const mockRemove = jest.fn();
 
 // Mock the dynamic import of the VFX library
-jest.mock('https://esm.sh/@vfx-js/core', () => {
-  return {
-    VFX: class MockVFX {
-      add = mockAdd;
-      remove = mockRemove;
-    }
-  };
-}, { virtual: true });
+jest.mock(
+  "https://esm.sh/@vfx-js/core",
+  () => {
+    return {
+      VFX: class MockVFX {
+        add = mockAdd;
+        remove = mockRemove;
+      },
+    };
+  },
+  { virtual: true },
+);
 
 const originalWarn = console.warn;
 
-describe('useVFXEffect', () => {
+describe("useVFXEffect", () => {
   beforeEach(() => {
     console.warn = jest.fn();
     mockAdd.mockClear();
@@ -27,33 +31,32 @@ describe('useVFXEffect', () => {
     console.warn = originalWarn;
   });
 
-  it('initializes VFX instance successfully', async () => {
+  it("initializes VFX instance successfully", async () => {
     renderHook(() => useVFXEffect({}));
 
     // Wait for dynamic import
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 10));
     });
 
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  it('handles VFX application error gracefully', async () => {
+  it("handles VFX application error gracefully", async () => {
     mockAdd.mockImplementation(() => {
       throw new Error("Simulated add error");
     });
 
-    const activeElement = document.createElement('div');
+    const activeElement = document.createElement("div");
 
     // Initial render
-    const { rerender } = renderHook(
-      (props) => useVFXEffect(props),
-      { initialProps: { activeElement: null as HTMLElement | null } }
-    );
+    const { rerender } = renderHook((props) => useVFXEffect(props), {
+      initialProps: { activeElement: null as HTMLElement | null },
+    });
 
     // Wait for init
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 10));
     });
 
     // Update activeElement
@@ -61,34 +64,33 @@ describe('useVFXEffect', () => {
 
     expect(console.warn).toHaveBeenCalledWith(
       "VFX application error:",
-      expect.any(Error)
+      expect.any(Error),
     );
   });
 
-  it('handles VFX removal error gracefully', async () => {
+  it("handles VFX removal error gracefully", async () => {
     mockRemove.mockImplementation(() => {
       throw new Error("Simulated remove error");
     });
 
-    const element1 = document.createElement('div');
-    const element2 = document.createElement('div');
+    const element1 = document.createElement("div");
+    const element2 = document.createElement("div");
 
     // Initial render with element1
-    const { rerender } = renderHook(
-      (props) => useVFXEffect(props),
-      { initialProps: { activeElement: element1 as HTMLElement | null } }
-    );
+    const { rerender } = renderHook((props) => useVFXEffect(props), {
+      initialProps: { activeElement: element1 as HTMLElement | null },
+    });
 
     // Wait for init and application to element1
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 10));
     });
 
     // Re-render to ensure previousActiveRef is updated
     rerender({ activeElement: element1 });
 
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 10));
     });
 
     // Change to element2 to trigger removal on element1
@@ -96,25 +98,24 @@ describe('useVFXEffect', () => {
 
     expect(console.warn).toHaveBeenCalledWith(
       "VFX removal error:",
-      expect.any(Error)
+      expect.any(Error),
     );
   });
 
-  it('cleans up effects silently on unmount', async () => {
+  it("cleans up effects silently on unmount", async () => {
     mockRemove.mockImplementation(() => {
       throw new Error("Simulated cleanup error");
     });
 
-    const activeElement = document.createElement('div');
+    const activeElement = document.createElement("div");
 
-    const { unmount, rerender } = renderHook(
-      (props) => useVFXEffect(props),
-      { initialProps: { activeElement: activeElement as HTMLElement | null } }
-    );
+    const { unmount, rerender } = renderHook((props) => useVFXEffect(props), {
+      initialProps: { activeElement: activeElement as HTMLElement | null },
+    });
 
     // Wait for init
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 10));
     });
 
     // Re-render to ensure element is registered in `previousActiveRef.current`
@@ -127,7 +128,7 @@ describe('useVFXEffect', () => {
     // So console.warn should not be called
     expect(console.warn).not.toHaveBeenCalledWith(
       "VFX removal error:",
-      expect.any(Error)
+      expect.any(Error),
     );
   });
 });

--- a/src/server/apiCors.test.js
+++ b/src/server/apiCors.test.js
@@ -2,14 +2,24 @@ import { isOriginAllowed } from "./apiCors.js";
 
 describe("apiCors", () => {
   it("should block empty origins", () => {
-    expect(isOriginAllowed("", { ALLOWED_ORIGINS: "https://example.com" })).toBe(false);
-    expect(isOriginAllowed(null, { ALLOWED_ORIGINS: "https://example.com" })).toBe(false);
-    expect(isOriginAllowed(undefined, { ALLOWED_ORIGINS: "https://example.com" })).toBe(false);
+    expect(
+      isOriginAllowed("", { ALLOWED_ORIGINS: "https://example.com" }),
+    ).toBe(false);
+    expect(
+      isOriginAllowed(null, { ALLOWED_ORIGINS: "https://example.com" }),
+    ).toBe(false);
+    expect(
+      isOriginAllowed(undefined, { ALLOWED_ORIGINS: "https://example.com" }),
+    ).toBe(false);
   });
 
   it("should evaluate global allow wildcard correctly", () => {
-    expect(isOriginAllowed("https://anything.com", { ALLOWED_ORIGINS: "*" })).toBe(true);
-    expect(isOriginAllowed("http://localhost:3000", { ALLOWED_ORIGINS: "*" })).toBe(true);
+    expect(
+      isOriginAllowed("https://anything.com", { ALLOWED_ORIGINS: "*" }),
+    ).toBe(true);
+    expect(
+      isOriginAllowed("http://localhost:3000", { ALLOWED_ORIGINS: "*" }),
+    ).toBe(true);
   });
 
   it("should match exact origins", () => {
@@ -25,7 +35,9 @@ describe("apiCors", () => {
     expect(isOriginAllowed("https://test.example.com", env)).toBe(true);
     // Should NOT match evil domain extensions or paths
     expect(isOriginAllowed("https://example.com.evil.com", env)).toBe(false);
-    expect(isOriginAllowed("https://evil.example.com.evil.com", env)).toBe(false);
+    expect(isOriginAllowed("https://evil.example.com.evil.com", env)).toBe(
+      false,
+    );
   });
 
   it("should correctly cache per environment string rather than globally", () => {

--- a/src/server/notionContent.js
+++ b/src/server/notionContent.js
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+
 const NOTION_API_BASE = "https://api.notion.com/v1";
 const NOTION_VERSION = "2022-06-28";
 
@@ -313,8 +314,12 @@ function transformProjectsData(results, projectContentByPageId = new Map()) {
           props.content?.rich_text ||
           props.Description?.rich_text ||
           [],
-      ) || projectContentByPageId.get(page.id) || "";
-    const rawHook = extractRichText(props.Hook?.rich_text || props.hook?.rich_text || []);
+      ) ||
+      projectContentByPageId.get(page.id) ||
+      "";
+    const rawHook = extractRichText(
+      props.Hook?.rich_text || props.hook?.rich_text || [],
+    );
 
     return {
       title: titleText,
@@ -339,8 +344,7 @@ function transformProjectsData(results, projectContentByPageId = new Map()) {
       keywords: extractMultiSelectNames(
         props.Keyword?.multi_select || props.keyword?.multi_select || [],
       ),
-      published:
-        extractCheckboxValue(props.Published, props.published) ?? true,
+      published: extractCheckboxValue(props.Published, props.published) ?? true,
       sortOrder: extractNumberValue(
         props["Sort Order"],
         props.SortOrder,
@@ -908,7 +912,9 @@ async function fetchProjectContentByPageId({
       });
       const pageContent = blocks
         .map(extractBlockPlainText)
-        .filter((blockText) => typeof blockText === "string" && blockText.length)
+        .filter(
+          (blockText) => typeof blockText === "string" && blockText.length,
+        )
         .join("\n\n");
 
       return [page.id, pageContent];
@@ -1016,7 +1022,7 @@ export async function queryNotionDatabase({
         )
       : databaseType === "work"
         ? prepareWorkForPublicDisplay(transformWorkData(rawResults))
-      : getDatasetTransformer(databaseType)(rawResults);
+        : getDatasetTransformer(databaseType)(rawResults);
 
   return validateDatasetRecords(databaseType, records);
 }
@@ -1367,9 +1373,8 @@ export async function getHealthSummary({
   };
 }
 
-
 function timingSafeCompare(a, b) {
-  if (typeof a !== 'string' || typeof b !== 'string') {
+  if (typeof a !== "string" || typeof b !== "string") {
     return false;
   }
 
@@ -1394,7 +1399,10 @@ export function isAuthorizedCronRequest(req, env = process.env) {
   const authorization = req.headers.authorization;
   const headerSecret = req.headers["x-cron-secret"];
 
-  const isBearerValid = timingSafeCompare(authorization || "", `Bearer ${secret}`);
+  const isBearerValid = timingSafeCompare(
+    authorization || "",
+    `Bearer ${secret}`,
+  );
   const isHeaderValid = timingSafeCompare(headerSecret || "", secret);
 
   return isBearerValid || isHeaderValid;
@@ -1419,10 +1427,10 @@ export function createErrorPayload(error) {
   }
 
   return {
-      error: {
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Internal server error",
-        failureType: "internal_server_error",
-      },
-    };
+    error: {
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Internal server error",
+      failureType: "internal_server_error",
+    },
+  };
 }

--- a/src/utils/shopUtils.ts
+++ b/src/utils/shopUtils.ts
@@ -39,23 +39,23 @@ export const handlePrintfulError = (
         "CORS Error: Unable to connect to Printful API. Please ensure the development server is running with the correct proxy configuration.";
     }
   } else if (typeof err === "object" && err !== null) {
-      const errObj = err as Record<string, unknown>;
-      const response = errObj.response as Record<string, unknown> | undefined;
-      const code = errObj.code as string | undefined;
-      const message = errObj.message as string | undefined;
+    const errObj = err as Record<string, unknown>;
+    const response = errObj.response as Record<string, unknown> | undefined;
+    const code = errObj.code as string | undefined;
+    const message = errObj.message as string | undefined;
 
-      if (response) {
-        errorMessage = `${context}: ${response.status} - ${response.statusText || message || 'Unknown Error'}`;
-      } else if (message) {
-        errorMessage = `${context}: undefined - ${message}`;
-      }
+    if (response) {
+      errorMessage = `${context}: ${response.status} - ${response.statusText || message || "Unknown Error"}`;
+    } else if (message) {
+      errorMessage = `${context}: undefined - ${message}`;
+    }
 
-      if (message === "Network Error" || code === "ERR_NETWORK") {
-        errorMessage =
-          "CORS Error: Unable to connect to Printful API. Please ensure the development server is running with the correct proxy configuration.";
-      }
+    if (message === "Network Error" || code === "ERR_NETWORK") {
+      errorMessage =
+        "CORS Error: Unable to connect to Printful API. Please ensure the development server is running with the correct proxy configuration.";
+    }
   } else if (typeof err === "string") {
-      errorMessage = `${context}: undefined - ${err}`;
+    errorMessage = `${context}: undefined - ${err}`;
   }
 
   return errorMessage;
@@ -99,12 +99,15 @@ export const parsePrintfulProduct = (product: unknown): ParsedProduct => {
 
   const syncProduct = (p.sync_product as PrintfulSyncProduct) || null;
   const syncVariants = (p.sync_variants as PrintfulSyncVariant[]) || [];
-  const firstVariant = Array.isArray(syncVariants) && syncVariants.length > 0
-    ? syncVariants[0] || null
-    : null;
-  const price = firstVariant?.retail_price && !Number.isNaN(Number(firstVariant.retail_price))
-    ? Number(firstVariant.retail_price)
-    : 0;
+  const firstVariant =
+    Array.isArray(syncVariants) && syncVariants.length > 0
+      ? syncVariants[0] || null
+      : null;
+  const price =
+    firstVariant?.retail_price &&
+    !Number.isNaN(Number(firstVariant.retail_price))
+      ? Number(firstVariant.retail_price)
+      : 0;
 
   return {
     syncProduct,


### PR DESCRIPTION
🎯 What:
The proxy server `scripts/server.js` was blindly forwarding unauthenticated, open CORS requests to the Notion API using the server's configured `NOTION_TOKEN`. Furthermore, it accepted arbitrary payload fields and forwarded them to the `query` database endpoint.

⚠️ Risk:
- **SSRF / Open Proxy**: A malicious script on an arbitrary domain or a local network user could abuse this endpoint to perform unauthenticated requests to the local proxy (bypassing browser CORS if run outside browser contexts or if the wildcard CORS allowed it). 
- **Arbitrary Modification / Injection**: By sending unsanitized query bodies, an attacker could manipulate Notion filters or exploit database query functionality beyond simple reads, consuming the server's rate limit or accessing private Notion blocks that they shouldn't query.

🛡️ Solution:
1. **Strict CORS configuration**: Updated `cors()` middleware to explicitly allow only `localhost` and `127.0.0.1` origins, denying requests from other web apps trying to reach the proxy server.
2. **Loopback IP restriction**: Added a middleware that validates `req.ip`, ensuring that even direct curl requests bypassing CORS can only be executed by the local machine.
3. **Payload Whitelisting**: Restricted `req.body` properties sent to Notion down to only `filter`, `sorts`, `page_size`, and `start_cursor`. Any other unexpected injection properties are silently dropped.

---
*PR created automatically by Jules for task [12329842095823318157](https://jules.google.com/task/12329842095823318157) started by @guitarbeat*