### PR TITLE
🧹 [Code Health] Extract Work component data processing

### DIFF
--- a/src/components/content/Work/Work.tsx
+++ b/src/components/content/Work/Work.tsx
@@ -1,6 +1,12 @@
 import moment from "moment";
 // Import required libraries and components
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 // import { withGoogleSheets } from "react-db-google-sheets";
 import { useNotion } from "../../../contexts/NotionContext";
 import { cn } from "../../../utils/commonUtils";
@@ -136,7 +142,6 @@ function TimelineBar({
   );
 }
 
-
 const CARD_EFFECTS = [
   {
     colors: ["#f8fafc", "#f1f5f9", "#cbd5e1"],
@@ -166,9 +171,44 @@ const MemoizedTimelineBar = React.memo(TimelineBar);
 
 interface WorkProps {
   db?: {
-
     work: unknown[];
   };
+}
+
+// Helper function to process job data outside component body
+function processJobsData(rawJobs: Job[]) {
+  const jobs: Job[] = rawJobs.map((job) => ({ ...job }));
+  let firstDate = moment();
+
+  // Format and enhance jobs data
+  for (const job of jobs) {
+    const _to_moment = job.to ? moment(job.to, "MM-YYYY") : moment();
+    const _from_moment = moment(job.from, "MM-YYYY");
+    const _duration = _to_moment.diff(_from_moment, "months");
+
+    job.from = _from_moment.format("MMM YYYY");
+    job.to = job.to ? _to_moment.format("MMM YYYY") : "Now";
+    job._from = _from_moment;
+    job._to = _to_moment;
+    job.date = _duration === 0 ? job.from : `${job.from} - ${job.to}`;
+    job.duration = _duration === 0 ? 1 : _duration;
+
+    if (firstDate.diff(_from_moment) > 0) {
+      firstDate = _from_moment;
+    }
+  }
+
+  const time_span = moment().diff(firstDate, "months");
+  const safe_time_span = time_span === 0 ? 1 : time_span;
+  for (const job of jobs) {
+    job.bar_start =
+      (100 * job._from.diff(firstDate, "months")) / safe_time_span;
+    job.bar_height = (100 * job.duration) / safe_time_span;
+  }
+
+  const jobBars = jobs.map((job) => [job.bar_height, job.bar_start]);
+
+  return { processedJobs: jobs, firstDate, jobBars };
 }
 
 // Function for Work component
@@ -198,40 +238,12 @@ function Work({ db: propsDb }: WorkProps = {}) {
   }, []);
 
   // Data processing
-  // Make a deep copy to avoid mutating the original data in context
-  const jobs: Job[] = ((db?.work || []) as Job[]).map((job) => ({
-    ...job,
-  })) as Job[];
-
-  let first_date = moment();
-
-  // Format and enhance jobs data
-  for (const job of jobs) {
-    const _to_moment = job.to ? moment(job.to, "MM-YYYY") : moment();
-    const _from_moment = moment(job.from, "MM-YYYY");
-    const _duration = _to_moment.diff(_from_moment, "months");
-
-    job.from = _from_moment.format("MMM YYYY");
-    job.to = job.to ? _to_moment.format("MMM YYYY") : "Now";
-    job._from = _from_moment;
-    job._to = _to_moment;
-    job.date = _duration === 0 ? job.from : `${job.from} - ${job.to}`;
-    job.duration = _duration === 0 ? 1 : _duration;
-
-    if (first_date.diff(_from_moment) > 0) {
-      first_date = _from_moment;
-    }
-  }
-
-  const time_span = moment().diff(first_date, "months");
-  const safe_time_span = time_span === 0 ? 1 : time_span;
-  for (const job of jobs) {
-    job.bar_start =
-      (100 * job._from.diff(first_date, "months")) / safe_time_span;
-    job.bar_height = (100 * job.duration) / safe_time_span;
-  }
-
-  const job_bars = jobs.map((job) => [job.bar_height, job.bar_start]);
+  const rawJobs = (db?.work || []) as Job[];
+  const {
+    processedJobs: jobs,
+    firstDate: first_date,
+    jobBars: job_bars,
+  } = useMemo(() => processJobsData(rawJobs), [rawJobs]);
 
   // Add intersection observer for lazy loading
   const [isVisible, setIsVisible] = useState(false);
@@ -318,6 +330,5 @@ function Work({ db: propsDb }: WorkProps = {}) {
     </div>
   );
 }
-
 
 export default Work;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted the lengthy job data processing logic inside the `Work` component (calculating dates, durations, bar heights, and start positions) into a dedicated `processJobsData` helper function outside the component body. This was integrated back into the component using the `useMemo` hook to memoize the processed output.

💡 **Why:** How this improves maintainability
This reduces the line length and complexity of the primary `Work` functional component, making the React rendering logic easier to read. By moving the processing logic to a pure helper function, it becomes easier to test in isolation in the future. Furthermore, utilizing `useMemo` ensures that these somewhat expensive date calculation operations (which use moment.js) are not unnecessarily rerun on every component re-render unless the underlying data source (`db.work`) changes.

✅ **Verification:** How you confirmed the change is safe
- Ran `pnpm run lint` with Biome to ensure formatting and lint checks passed.
- Ran `pnpm test src/components/content/Work/Work.test.tsx` and the full suite (`pnpm test`) to ensure unit tests passed.
- Ran `pnpm exec tsc --noEmit` to verify type safety.
- Manually cleaned and ignored build artifacts inside `dist` to ensure only the source code modification was staged.

✨ **Result:** The improvement achieved
A cleaner, shorter, and more performant `Work` component with separated concerns.

---
*PR created automatically by Jules for task [11529958835266411045](https://jules.google.com/task/11529958835266411045) started by @guitarbeat*

## Summary by Sourcery

Extract Work timeline job data processing into a reusable helper and memoize its use in the component

Enhancements:
- Move job date and timeline bar calculation logic from the Work component into a dedicated processJobsData helper function
- Use React.useMemo in the Work component to memoize processed job data and derived bar positions based on the work dataset