### PR TITLE
🔒 Fix insecure CORS wildcard regex generation

### DIFF
--- a/src/server/apiCors.js
+++ b/src/server/apiCors.js
@@ -33,6 +33,11 @@ function buildCorsConfig(env = process.env) {
   const regexes = [];
 
   for (const part of parts) {
+    if (!part.startsWith("http://") && !part.startsWith("https://")) {
+      console.warn(`[CORS] Invalid origin ignored: ${part}. Must start with http:// or https://`);
+      continue;
+    }
+
     if (part.includes("*")) {
       const escaped = part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const regexStr = `^${escaped.replace(/\\\*/g, "[a-zA-Z0-9-]+")}$`;

--- a/src/server/apiCors.test.js
+++ b/src/server/apiCors.test.js
@@ -40,4 +40,10 @@ describe("apiCors", () => {
     expect(isOriginAllowed("https://env2.com", env2)).toBe(true);
     expect(isOriginAllowed("https://env1.com", env2)).toBe(false);
   });
+
+  it("should ignore origins without valid protocols", () => {
+    const env = { ALLOWED_ORIGINS: "example.com,*.example.com" };
+    expect(isOriginAllowed("https://example.com", env)).toBe(false);
+    expect(isOriginAllowed("https://test.example.com", env)).toBe(false);
+  });
 });


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `buildCorsConfig` function in `src/server/apiCors.js` lacked protocol boundary checks for origins defined in the `ALLOWED_ORIGINS` environment variable. When wildcards (`*`) were used, it converted the origin string into a regular expression without ensuring the presence of a strict protocol scheme like `http://` or `https://`.

⚠️ **Risk:** The potential impact if left unfixed
Without validating the protocol, a wildcard configuration like `*.example.com` would compile into a regular expression `^[a-zA-Z0-9-]+\.example\.com$`. This overly permissive regex lacks protocol anchoring, potentially allowing origins using unexpected schemes or structures that bypass the intended CORS domain restrictions.

🛡️ **Solution:** How the fix addresses the vulnerability
Added a validation check inside the parsing loop to ensure each defined origin explicitly starts with `http://` or `https://` (ignoring the global `*` wildcard which is handled separately). Origins lacking a valid protocol are skipped, and a warning is logged. This ensures that any generated regular expression firmly anchors to a safe web protocol boundary. Added a corresponding test case to prevent regression.

---
*PR created automatically by Jules for task [11012739454222175284](https://jules.google.com/task/11012739454222175284) started by @guitarbeat*