### PR TITLE
🧪 Add tests for useVFXEffect classList error handling paths

### DIFF
--- a/src/hooks/__tests__/useVFXEffect.test.ts
+++ b/src/hooks/__tests__/useVFXEffect.test.ts
@@ -100,6 +100,73 @@ describe('useVFXEffect', () => {
     );
   });
 
+  it('handles classList removal error gracefully', async () => {
+    const element1 = document.createElement('div');
+    const element2 = document.createElement('div');
+
+    // Make classList.remove throw
+    Object.defineProperty(element1, 'classList', {
+      value: {
+        add: jest.fn(),
+        remove: jest.fn(() => {
+          throw new Error("Simulated classList remove error");
+        })
+      }
+    });
+
+    const { rerender } = renderHook(
+      (props) => useVFXEffect(props),
+      { initialProps: { activeElement: element1 as HTMLElement | null } }
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+
+    rerender({ activeElement: element1 });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+
+    rerender({ activeElement: element2 });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "VFX removal error:",
+      expect.any(Error)
+    );
+  });
+
+  it('handles active classList addition error gracefully', async () => {
+    const activeElement = document.createElement('div');
+
+    // Make classList.add throw
+    Object.defineProperty(activeElement, 'classList', {
+      value: {
+        add: jest.fn(() => {
+          throw new Error("Simulated classList add error");
+        }),
+        remove: jest.fn()
+      }
+    });
+
+    const { rerender } = renderHook(
+      (props) => useVFXEffect(props),
+      { initialProps: { activeElement: null as HTMLElement | null } }
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+
+    rerender({ activeElement });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "VFX application error:",
+      expect.any(Error)
+    );
+  });
+
   it('cleans up effects silently on unmount', async () => {
     mockRemove.mockImplementation(() => {
       throw new Error("Simulated cleanup error");


### PR DESCRIPTION
🎯 **What:** The testing gap addressed in `useVFXEffect.ts` for the `classList.add` and `classList.remove` error paths within the `add` and `remove` try-catch blocks.

📊 **Coverage:** The `try/catch` blocks in `useEffect` covering `vfxRef.current.add(activeElement)` and `vfxRef.current.remove(previousActiveRef.current)` previously relied on `vfxRef` throwing errors to be tested. The new tests ensure that if the `classList.add` or `classList.remove` throws (which are inside the same `try` blocks), the error is correctly caught and logged.

✨ **Result:** Test coverage for `src/hooks/useVFXEffect.ts` is now 100% across all metrics (Lines, Branch, Functions, Statements).

---
*PR created automatically by Jules for task [12174482982636172844](https://jules.google.com/task/12174482982636172844) started by @guitarbeat*