### PR TITLE
🔒 Fix missing noopener noreferrer on target blank link in Projects

### DIFF
--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,8 @@
+🎯 **What:** The vulnerability fixed
+Added `noopener noreferrer` to the `rel` attribute for links that open in a new tab (`target="_blank"`) in `Projects.tsx`.
+
+⚠️ **Risk:** The potential impact if left unfixed
+Missing `noopener noreferrer` on `target="_blank"` links can expose the site to reverse tabnabbing attacks, where the newly opened tab can manipulate the original window's location or access its `window.opener` object on older browsers.
+
+🛡️ **Solution:** How the fix addresses the vulnerability
+By explicitly adding `noopener noreferrer` to the `rel` attribute when `target="_blank"` is used, we ensure that the newly opened tab runs in a separate process and cannot access the `window.opener` object, preventing reverse tabnabbing attacks and adhering to modern web security best practices.

--- a/src/components/content/Projects/Projects.tsx
+++ b/src/components/content/Projects/Projects.tsx
@@ -103,7 +103,7 @@ function ProjectCard({
     <a
       href={link || undefined}
       target={link ? "_blank" : undefined}
-      rel={link ? "noreferrer" : undefined}
+      rel={link ? "noopener noreferrer" : undefined}
       className={cn(`projects__card ${className}`.trim(), image && "has-image")}
       key={slug}
       onClick={handleClick}


### PR DESCRIPTION
🎯 **What:**
Added `noopener noreferrer` to the `rel` attribute for links that open in a new tab (`target="_blank"`) in `Projects.tsx`.

⚠️ **Risk:**
Missing `noopener noreferrer` on `target="_blank"` links can expose the site to reverse tabnabbing attacks, where the newly opened tab can manipulate the original window's location or access its `window.opener` object on older browsers.

🛡️ **Solution:**
By explicitly adding `noopener noreferrer` to the `rel` attribute when `target="_blank"` is used, we ensure that the newly opened tab runs in a separate process and cannot access the `window.opener` object, preventing reverse tabnabbing attacks and adhering to modern web security best practices.

---
*PR created automatically by Jules for task [13015971011014603092](https://jules.google.com/task/13015971011014603092) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Ensure project card links opened in a new tab include "noopener noreferrer" in the rel attribute to mitigate security risks.