### PR TITLE
🧪 Add test for error path in filter validation catch blocks

### DIFF
--- a/src/server/notionContent.test.js
+++ b/src/server/notionContent.test.js
@@ -3,6 +3,7 @@ import {
   getContentResponse,
   getHealthSummary,
   isAuthorizedCronRequest,
+  validateQueryBody,
   queryNotionDatabase,
   refreshContentSnapshot,
   SNAPSHOT_KEY,
@@ -588,6 +589,40 @@ describe("notionContent server helpers", () => {
         { CRON_SECRET: "top-secret" },
       ),
     ).toBe(false);
+  });
+
+
+  it("drops invalid properties gracefully due to parsing errors", () => {
+    // Create a filter with a circular reference that will cause JSON.stringify to throw
+    const circularRef = {};
+    circularRef.self = circularRef;
+
+    const filter = {
+      property: "title",
+      title: circularRef,
+      // Add a valid property so the filter isn't completely dropped if not necessary.
+      // validateFilter requires at least one parsed key for hasType = true.
+      rich_text: { equals: "test" }
+    };
+
+    const validBody = validateQueryBody({ filter });
+    expect(validBody.filter).toEqual({
+      property: "title",
+      rich_text: { equals: "test" }
+    });
+  });
+
+  it("drops timestamp filters gracefully due to parsing errors", () => {
+    const circularRef = {};
+    circularRef.self = circularRef;
+
+    const filter = {
+      timestamp: "created_time",
+      created_time: circularRef
+    };
+
+    const validBody = validateQueryBody({ filter });
+    expect(validBody.filter).toBeUndefined();
   });
 
   it("sanitizes public error payloads", () => {


### PR DESCRIPTION
🎯 **What:** Add error path test for catch block in `validateQueryBody` in `src/server/notionContent.js`.

📊 **Coverage:** Covered handling of JSON serialization failures caused by circular references in valid filter inputs (where it gracefully continues using parsed fields) and timestamp inputs (where it gracefully falls back to `null`).

✨ **Result:** Improved test reliability and ensured graceful failure conditions are well-defined for Notion API request validations.

---
*PR created automatically by Jules for task [5770882511788301862](https://jules.google.com/task/5770882511788301862) started by @guitarbeat*

## Summary by Sourcery

Add tests covering error-path behavior in query filter validation when JSON serialization fails.

Tests:
- Add test ensuring filter properties with circular references are dropped while valid parts are retained.
- Add test ensuring timestamp-based filters with unparsable values are fully dropped from the validated query body.