### PR TITLE
🧪 Add error path test for playKnightRiderTheme

### DIFF
--- a/src/utils/__tests__/audioUtils.test.ts
+++ b/src/utils/__tests__/audioUtils.test.ts
@@ -1,0 +1,33 @@
+import audioManager from "../audioUtils";
+
+describe("AudioManager", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    audioManager.cleanup();
+  });
+
+  describe("playKnightRiderTheme", () => {
+    it("handles errors gracefully and returns false", async () => {
+      // Force an error to trigger the catch block
+      jest
+        .spyOn(audioManager, "initAudioContext")
+        .mockRejectedValue(new Error("Forced test error"));
+
+      const handleAudioErrorSpy = jest.spyOn(audioManager, "handleAudioError");
+
+      const result = await audioManager.playKnightRiderTheme();
+
+      expect(result).toBe(false);
+      expect(console.error).toHaveBeenCalledWith(
+        "Error playing Knight Rider theme:",
+        expect.any(Error),
+      );
+      expect(handleAudioErrorSpy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Add an error path test for the catch block inside `playKnightRiderTheme` in `src/utils/audioUtils.ts`.
📊 **Coverage:** Successfully asserts that when `initAudioContext` fails, the error is safely caught, `console.error` logs the error, `handleAudioError` is called, and `false` is safely returned.
✨ **Result:** Improved test reliability by covering the primary failure fallback for background audio playback.

---
*PR created automatically by Jules for task [18185690222374131275](https://jules.google.com/task/18185690222374131275) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add a Jest test verifying playKnightRiderTheme logs errors, calls handleAudioError, and returns false when initAudioContext rejects.