### PR TITLE
🧪 Add error path tests for refreshContentSnapshot

### DIFF
--- a/src/server/notionContent.test.js
+++ b/src/server/notionContent.test.js
@@ -420,6 +420,56 @@ describe("notionContent server helpers", () => {
     );
   });
 
+  it("throws an error when kvClient.setJson fails and requireSnapshotPersist is true", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      mockResponse({
+        results: [],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+    const kvClient = {
+      getJson: jest.fn(),
+      setJson: jest.fn().mockRejectedValue(new Error("KV write failed")),
+    };
+
+    await expect(
+      refreshContentSnapshot({
+        fetchImpl,
+        env: { NOTION_TOKEN: "test-token" },
+        kvClient,
+        now: new Date("2026-03-21T12:00:00.000Z"),
+        requireSnapshotPersist: true,
+      }),
+    ).rejects.toThrow("KV write failed");
+  });
+
+  it("swallows the error and returns snapshotStored=false when kvClient.setJson fails and requireSnapshotPersist is false", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      mockResponse({
+        results: [],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+    const kvClient = {
+      getJson: jest.fn(),
+      setJson: jest.fn().mockRejectedValue(new Error("KV write failed")),
+    };
+
+    const result = await refreshContentSnapshot({
+      fetchImpl,
+      env: { NOTION_TOKEN: "test-token" },
+      kvClient,
+      now: new Date("2026-03-21T12:00:00.000Z"),
+      requireSnapshotPersist: false,
+    });
+
+    expect(result.snapshotStored).toBe(false);
+    expect(result.response.meta.snapshotUpdatedAt).toBeNull();
+    expect(result.response.meta.source).toBe("live");
+  });
+
   it("returns the KV snapshot with degraded=true when live refresh fails", async () => {
     const kvClient = {
       getJson: jest.fn().mockResolvedValue(snapshotEnvelope),


### PR DESCRIPTION
🎯 **What:** Added unit tests covering the error-handling paths for `kvClient.setJson` within `src/server/notionContent.js`, specifically testing the `catch` block behavior when `requireSnapshotPersist` is true vs. false.

📊 **Coverage:**
- When `kvClient.setJson` fails and `requireSnapshotPersist` is true, the error is successfully rethrown.
- When `kvClient.setJson` fails and `requireSnapshotPersist` is false, the error is swallowed and `snapshotStored` is false.

✨ **Result:** Improved test coverage for the complex error handling logic in `refreshContentSnapshot`. No regressions were introduced.

---
*PR created automatically by Jules for task [5165911694244383914](https://jules.google.com/task/5165911694244383914) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add unit tests covering refreshContentSnapshot behavior when kvClient.setJson fails with requireSnapshotPersist enabled or disabled.