### PR TITLE
🧪 Add error path test for Notion block children fetch

### DIFF
--- a/src/server/notionContent.test.js
+++ b/src/server/notionContent.test.js
@@ -603,4 +603,44 @@ describe("notionContent server helpers", () => {
       },
     });
   });
+
+  it("throws ContentError with NOTION_REQUEST_FAILED when fetching block children fails", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(
+        mockResponse({
+          results: [
+            {
+              id: "project-error-page",
+              properties: {
+                Name: { title: [{ plain_text: "Project Error" }] },
+                Date: { number: 2024 },
+                Link: { url: "https://example.com/project-error" },
+                Slug: { rich_text: [{ plain_text: "project-error" }] },
+                Published: { checkbox: true },
+              },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        }),
+      )
+      .mockRejectedValueOnce(new Error("Network Error"));
+
+    await expect(
+      queryNotionDatabase({
+        databaseType: "projects",
+        fetchImpl,
+        env: { NOTION_TOKEN: "test-token" },
+      }),
+    ).rejects.toMatchObject({
+      code: "NOTION_REQUEST_FAILED",
+      failureType: "notion_request_failed",
+      message: "Failed to reach Notion block API.",
+      details: {
+        blockId: "project-error-page",
+        message: "Network Error",
+      },
+    });
+  });
 });


### PR DESCRIPTION
🎯 **What:**
Added a test to cover the catch block within fetchNotionBlockChildren when fetching block data fails.

📊 **Coverage:**
Complex error handling and fallback logic inside queryNotionDatabase requires verification to ensure correct error status mapping and detail exposure.

✨ **Result:**
Test coverage gap addressed; potential network failures are now explicitly simulated and verified in test pipelines.

---
*PR created automatically by Jules for task [13992710991368899872](https://jules.google.com/task/13992710991368899872) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add a regression test that verifies ContentError is thrown with NOTION_REQUEST_FAILED when Notion block children fetching fails.