### PR TITLE
Fix API key comment in vite.config.ts and clean up GOOGLE_SHEETS_CONFIG

### DIFF
--- a/src/components/Core/constants.ts
+++ b/src/components/Core/constants.ts
@@ -1,10 +1,5 @@
 export const GOOGLE_SHEETS_CONFIG = {
-  // Security Fix: API Key removed from client bundle.
-  // This integration is currently disabled. If re-enabled, use a backend proxy.
-  apiKey: undefined,
   discoveryDocs: ["https://sheets.googleapis.com/$discovery/rest?version=v4"],
-  // Security Fix: Doc ID removed from client bundle.
-  spreadsheetId: undefined,
   dataLoading: {
     component: () => null,
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -166,7 +166,7 @@ export default defineConfig(({ mode }) => {
           process.env.REACT_APP_ENABLE_VERCEL_ANALYTICS ||
           "",
       ),
-      // Security Fix: Google Sheets API keys removed to prevent client-side exposure
+      // Security Fix: Printful API keys removed to prevent client-side exposure
       "process.env.REACT_APP_PRINTFUL_API_KEY": JSON.stringify(""),
       "process.env.REACT_APP_PRINTFUL_STORE_ID": JSON.stringify(""),
       "process.env.REACT_APP_GIT_COMMIT_HASH": JSON.stringify(""),


### PR DESCRIPTION
🎯 **What**
Fixed a comment in `vite.config.ts` that erroneously referenced "Google Sheets API keys" instead of the actual `Printful API keys` that follow it. Safely cleaned up the remnants of the removed `apiKey` and `spreadsheetId` fields from the exported `GOOGLE_SHEETS_CONFIG` in `src/components/Core/constants.ts`.

💡 **Why**
The mismatched comment in `vite.config.ts` was confusing as the Google Sheets integration was already removed. Additionally, leaving explicit `undefined` declarations for removed sensitive fields in `GOOGLE_SHEETS_CONFIG` added unnecessary clutter to the codebase. This cleanup ensures documentation and configuration objects remain accurate and concise.

✅ **Verification**
Verified that no TypeScript or build issues were introduced by running `pnpm exec tsc --noEmit`. Ran the full test suite (`pnpm test`), and all 23 suites passed successfully, confirming no regressions.

✨ **Result**
The codebase now accurately reflects the configuration status without confusing outdated comments, improving code health and maintainability.

---
*PR created automatically by Jules for task [8673354661779893763](https://jules.google.com/task/8673354661779893763) started by @guitarbeat*

## Summary by Sourcery

Clean up legacy Google Sheets configuration and correct a misleading security comment for Printful API keys.

Enhancements:
- Remove deprecated Google Sheets apiKey and spreadsheetId placeholders from GOOGLE_SHEETS_CONFIG to simplify configuration.
- Update vite.config.ts comment to accurately describe removal of Printful API keys from the client bundle.