### PR TITLE
⚡ Fix iOS backdrop-filter performance

### DIFF
--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -263,6 +263,10 @@ body {
   .glass-effect {
     backdrop-filter: blur(10px);
     will-change: backdrop-filter;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
   }
 }
 


### PR DESCRIPTION
🎯 **What**
Added hardware acceleration properties to `.glass-effect` inside the `@supports (-webkit-backdrop-filter: none)` block in `src/sass/base/_base.scss`.

💡 **Why**
To fix `backdrop-filter` performance issues and rendering glitches on iOS Safari.

✅ **Verification**
Verified that the properties (`-webkit-transform`, `transform`, `-webkit-backface-visibility`, `backface-visibility`) were added correctly. Ran the full test suite (`pnpm test`), and all tests passed.

✨ **Result**
Improved rendering performance for glass effect on iOS devices.

---
*PR created automatically by Jules for task [7675557651824540394](https://jules.google.com/task/7675557651824540394) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Optimize .glass-effect styling with hardware-accelerated transform and backface visibility properties when -webkit-backdrop-filter is supported.