### PR TITLE
🧪 Add missing error path tests in NotionContext

### DIFF
--- a/src/contexts/NotionContext.test.tsx
+++ b/src/contexts/NotionContext.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, renderHook } from "@testing-library/react";
 
 import { NotionProvider, useNotion } from "./NotionContext";
 
@@ -24,6 +24,8 @@ const Consumer = () => {
       <p>{notion.isDegraded ? "degraded" : "live"}</p>
       <p>{notion.lastUpdated || "no-last-updated"}</p>
       <p>{notion.db.projects[0]?.title || "no-projects"}</p>
+      <p>{notion.error || "no-error"}</p>
+      <p>{notion.loading ? "loading" : "not-loading"}</p>
     </div>
   );
 };
@@ -71,6 +73,35 @@ describe("NotionProvider", () => {
       expect(screen.getByText("degraded")).toBeInTheDocument();
       expect(screen.getByText("2026-03-21T10:00:00.000Z")).toBeInTheDocument();
       expect(screen.getByText("Project One")).toBeInTheDocument();
+      expect(screen.getByText("not-loading")).toBeInTheDocument();
     });
+  });
+
+  it("handles errors when fetching data fails", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const errorMessage = "Network Error";
+    mockGetAllData.mockRejectedValue(new Error(errorMessage));
+
+    render(
+      <NotionProvider>
+        <Consumer />
+      </NotionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("not-loading")).toBeInTheDocument();
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+      expect(screen.getByText("no-projects")).toBeInTheDocument();
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it("throws an error if useNotion is used outside NotionProvider", () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useNotion())).toThrow(
+      "useNotion must be used within NotionProvider"
+    );
+    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
🎯 **What:** Added missing tests for the error handling path in `NotionContext` when `mockGetAllData` rejects with an error. Included a test to verify context consumer throws an error if used outside of `NotionProvider`.
📊 **Coverage:** Now successfully testing the degraded error state (`not-loading`, sets error message properly, exposes empty data), increasing overall coverage of `NotionContext.tsx`. Also added a safety test for using `useNotion` outside the provider.
✨ **Result:** Improved test reliability and coverage. Ensured that error states do not regress and behave as expected for context consumers.

---
*PR created automatically by Jules for task [11234214664631019002](https://jules.google.com/task/11234214664631019002) started by @guitarbeat*

## Summary by Sourcery

Add tests covering NotionContext error handling and usage constraints.

Tests:
- Add a test verifying NotionProvider exposes correct non-loading degraded state and error message when data fetching fails and returns empty projects.
- Add a test ensuring useNotion throws a descriptive error when called outside of NotionProvider.