### PR TITLE
🔒 Replace innerHTML with textContent in useScrambleEffect to eliminate XSS vulnerability pattern

### DIFF
--- a/src/components/content/Header/useScrambleEffect.ts
+++ b/src/components/content/Header/useScrambleEffect.ts
@@ -28,11 +28,7 @@ export default function useScrambleEffect(
           for (const letter of letters) {
             const span = document.createElement("span");
             span.className = "letter";
-            if (letter === " ") {
-              span.innerHTML = "&nbsp;";
-            } else {
-              span.textContent = letter;
-            }
+            span.textContent = letter === " " ? " " : letter;
             fragment.appendChild(span);
           }
           header.appendChild(fragment);


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Replaced the use of `.innerHTML` in `useScrambleEffect.ts` with `.textContent` for assigning non-breaking spaces.

⚠️ **Risk:** The potential impact if left unfixed
While the hardcoded string `&nbsp;` was technically safe, using `.innerHTML` is generally a bad practice and can trigger security scanning tools indicating a potential XSS (Cross-Site Scripting) vulnerability vector if the assigned data were ever to become dynamic or user-controlled.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced `span.innerHTML = "&nbsp;";` and `span.textContent = letter;` with a single secure ternary expression using `.textContent`: `span.textContent = letter === " " ? "\u00A0" : letter;`. This eliminates the security risk entirely while preserving identical DOM functionality and layout behavior.

---
*PR created automatically by Jules for task [1198473687779926340](https://jules.google.com/task/1198473687779926340) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Remove innerHTML usage in the header scramble effect to eliminate a potential XSS vulnerability pattern.