### PR TITLE
🧹 Refactor VFXEffect custom hook to resolve 'any' type loose lint warning

### DIFF
--- a/src/hooks/useVFXEffect.ts
+++ b/src/hooks/useVFXEffect.ts
@@ -18,6 +18,11 @@ interface VFXEffectConfig {
   overflow?: number;
 }
 
+interface VFXInstance {
+  add(element: HTMLElement, config?: VFXEffectConfig): void;
+  remove(element: HTMLElement): void;
+}
+
 interface VFXOptions {
   enabled?: boolean;
   activeElement?: HTMLElement | null;
@@ -29,8 +34,7 @@ export const useVFXEffect = ({
   activeElement = null,
   effectConfig = { shader: "rgbShift", overflow: 100 },
 }: VFXOptions) => {
-  // biome-ignore lint/suspicious/noExplicitAny: VFX library type definition is loose
-  const vfxRef = useRef<any>(null);
+  const vfxRef = useRef<VFXInstance | null>(null);
   const previousActiveRef = useRef<HTMLElement | null>(null);
 
   // * Initialize VFX instance


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the usage of an explicit `any` type for the `vfxRef` in `useVFXEffect.ts`, which required a lint override.

💡 **Why:** Adding a defined interface `VFXInstance` mapping to the specific used methods ensures type safety and enhances code clarity and maintainability compared to the generic `any` type.

✅ **Verification:** Verified by running `npx @biomejs/biome check` to confirm that lint passes without warnings. Ran `pnpm test` and all 126 tests executed and passed without any regressions.

✨ **Result:** Improved maintainability and codebase cleanliness by resolving the `suspicious/noExplicitAny` warning and avoiding an unnecessary suppress comment.

---
*PR created automatically by Jules for task [10281069280652473705](https://jules.google.com/task/10281069280652473705) started by @guitarbeat*

## Summary by Sourcery

Improve type safety of the VFXEffect hook by replacing the explicit any ref with a typed VFXInstance interface.

Enhancements:
- Introduce a VFXInstance interface capturing the VFX library methods used by the hook.
- Update the VFXEffect hook to use a strongly typed ref instead of an any ref, removing the need for lint suppression.