### PR TITLE
🧹 Fix empty catch block in notionContent.js

### DIFF
--- a/src/server/notionContent.js
+++ b/src/server/notionContent.js
@@ -746,7 +746,9 @@ function validateFilter(filter, depth = 0) {
         try {
           nextFilter[key] = JSON.parse(JSON.stringify(filter[key]));
           hasType = true;
-        } catch (_error) {}
+        } catch (error) {
+          console.error("Failed to parse filter property:", error);
+        }
       }
     }
 


### PR DESCRIPTION
🎯 **What:** Modified the empty catch block in `src/server/notionContent.js` at line 749 to log the `error` using `console.error("Failed to parse filter property:", error);`.
💡 **Why:** Empty catch blocks swallow errors silently, making debugging difficult. Logging the error improves maintainability without changing the behavior or crashing the application.
✅ **Verification:** Verified the fix by running the full test suite (`pnpm test`), which passed successfully and accurately logged the `Failed to parse filter property: TypeError: Converting circular structure to JSON` error when given invalid data in `notionContent.test.js`.
✨ **Result:** Improved codebase health and easier troubleshooting for Notion filter parsing issues.

---
*PR created automatically by Jules for task [8475671239868023067](https://jules.google.com/task/8475671239868023067) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Add console logging for JSON parsing failures in filter validation to avoid silent error swallowing.