### PR TITLE
🔒 Fix insecure PRNG in MatrixDrop

### DIFF
--- a/src/components/effects/Matrix/MatrixDrop.ts
+++ b/src/components/effects/Matrix/MatrixDrop.ts
@@ -1,5 +1,19 @@
 import { MATRIX_RAIN } from "./constants";
 
+const randomArray = new Uint32Array(1);
+
+const secureRandom = (): number => {
+  if (
+    typeof window !== "undefined" &&
+    window.crypto &&
+    window.crypto.getRandomValues
+  ) {
+    window.crypto.getRandomValues(randomArray);
+    return randomArray[0] / 4294967296;
+  }
+  return Math.random();
+};
+
 export class Drop {
   x: number;
   y: number;
@@ -18,24 +32,24 @@ export class Drop {
     this.y = -100;
     this.char =
       MATRIX_RAIN.ALPHABET[
-        Math.floor(Math.random() * MATRIX_RAIN.ALPHABET.length)
+        Math.floor(secureRandom() * MATRIX_RAIN.ALPHABET.length)
       ];
-    this.changeInterval = Math.random() * 50 + 15;
+    this.changeInterval = secureRandom() * 50 + 15;
     this.frame = 0;
-    this.brightness = Math.random() > 0.95;
-    this.trailLength = Math.floor(Math.random() * 3) + 2;
+    this.brightness = secureRandom() > 0.95;
+    this.trailLength = Math.floor(secureRandom() * 3) + 2;
     this.trail = [];
     this.initializeCharacterProperties();
   }
 
   initializeCharacterProperties() {
-    this.speed = Math.random() * 2 + 0.8;
+    this.speed = secureRandom() * 2 + 0.8;
     this.fontSize = Math.floor(
-      Math.random() *
+      secureRandom() *
         (MATRIX_RAIN.FONT_SIZES.MAX - MATRIX_RAIN.FONT_SIZES.MIN) +
         MATRIX_RAIN.FONT_SIZES.MIN,
     );
-    this.opacity = Math.random() * 0.6 + 0.3;
+    this.opacity = secureRandom() * 0.6 + 0.3;
   }
 
   update(canvasHeight: number) {
@@ -51,10 +65,10 @@ export class Drop {
     if (this.frame >= this.changeInterval) {
       this.char =
         MATRIX_RAIN.ALPHABET[
-          Math.floor(Math.random() * MATRIX_RAIN.ALPHABET.length)
+          Math.floor(secureRandom() * MATRIX_RAIN.ALPHABET.length)
         ];
       this.frame = 0;
-      this.brightness = Math.random() > 0.97;
+      this.brightness = secureRandom() > 0.97;
     }
 
     if (canvasHeight && this.y * this.fontSize > canvasHeight) {


### PR DESCRIPTION
🎯 **What**
Replaced the use of `Math.random()` with `window.crypto.getRandomValues()` in the MatrixDrop class.

⚠️ **Risk**
While used only for visual effects in this context, static analysis tools (SAST) flag `Math.random()` as an insecure PRNG (CWE-338). Standardizing on `crypto.getRandomValues()` prevents security warnings and establishes better defaults.

🛡️ **Solution**
Implemented a `secureRandom()` helper function that uses the Web Crypto API. To avoid performance degradation and garbage collection overhead in the high-frequency Matrix rendering loop, it instantiates and reuses a shared `Uint32Array(1)` instance. It safely falls back to `Math.random()` in environments where `window.crypto` is unavailable (e.g. SSR contexts).

---
*PR created automatically by Jules for task [684428442987294109](https://jules.google.com/task/684428442987294109) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Introduce a shared secureRandom() helper that standardizes random value generation for MatrixDrop visual properties while minimizing allocation overhead.