### PR TITLE
🧪 Add tests for parseJsonSafely error path

### DIFF
--- a/src/server/notionContent.js
+++ b/src/server/notionContent.js
@@ -30,7 +30,7 @@ export class ContentError extends Error {
   }
 }
 
-function parseJsonSafely(value) {
+export function parseJsonSafely(value) {
   if (typeof value !== "string") {
     return value ?? null;
   }

--- a/src/server/notionContent.test.js
+++ b/src/server/notionContent.test.js
@@ -8,6 +8,7 @@ import {
   refreshContentSnapshot,
   SNAPSHOT_KEY,
   SNAPSHOT_META_KEY,
+  parseJsonSafely,
 } from "./notionContent";
 
 const mockResponse = (payload, { ok = true, status = 200 } = {}) => ({
@@ -726,6 +727,27 @@ describe("notionContent server helpers", () => {
         blockId: "project-error-page",
         message: "Network Error",
       },
+    });
+  });
+
+  describe("parseJsonSafely", () => {
+    it("returns the original string when given malformed JSON", () => {
+      const malformedJson = "{ invalid: json }";
+      const result = parseJsonSafely(malformedJson);
+      expect(result).toBe(malformedJson);
+    });
+
+    it("returns null or the original value when given non-string types", () => {
+      expect(parseJsonSafely(null)).toBeNull();
+      expect(parseJsonSafely(123)).toBe(123);
+      expect(parseJsonSafely(undefined)).toBeNull();
+
+      const obj = { key: "value" };
+      expect(parseJsonSafely(obj)).toBe(obj);
+    });
+
+    it("parses valid JSON correctly", () => {
+      expect(parseJsonSafely('{"valid": "json"}')).toEqual({ valid: "json" });
     });
   });
 });


### PR DESCRIPTION
🎯 **What:** Exported `parseJsonSafely` in `src/server/notionContent.js` and added unit tests in `src/server/notionContent.test.js` to verify its error path and fallback behaviors.

📊 **Coverage:** Covered malformed JSON strings, non-string inputs (null, numbers, objects), and valid JSON strings, ensuring correct fallback and parsing behaviors.

✨ **Result:** Improved test coverage and reliability for JSON parsing within the Notion content integration.

---
*PR created automatically by Jules for task [14624102989805613856](https://jules.google.com/task/14624102989805613856) started by @guitarbeat*

## Summary by Sourcery

Export parseJsonSafely and add unit coverage for its error and fallback behavior in the Notion content server helpers.

New Features:
- Expose parseJsonSafely as a named export from the Notion content server module.

Tests:
- Add tests covering parseJsonSafely behavior with malformed JSON, non-string inputs, and valid JSON strings.