### PR TITLE
🧹 [Code Health] Remove 'any' types in AuthContext.tsx

### DIFF
--- a/src/components/effects/Matrix/AuthContext.tsx
+++ b/src/components/effects/Matrix/AuthContext.tsx
@@ -86,8 +86,7 @@ const clearSessionData = (key: string) => {
   }
 };
 
-// biome-ignore lint/suspicious/noExplicitAny: Generic value for storage
-const setSessionData = (key: string, value: any) => {
+const setSessionData = (key: string, value: unknown) => {
   if (!hasSessionStorage()) {
     return;
   }
@@ -96,8 +95,7 @@ const setSessionData = (key: string, value: any) => {
     window.sessionStorage.setItem(key, JSON.stringify(value));
   } catch (error) {
     console.warn(`${ERROR_MESSAGES.STORAGE_ERROR} for ${key}:`, error);
-    // biome-ignore lint/suspicious/noExplicitAny: Generic error handling
-    if ((error as any).name === "QuotaExceededError") {
+    if (error instanceof Error && error.name === "QuotaExceededError") {
       try {
         // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach used for side effect
         Object.values(SESSION_KEYS).forEach((k) => clearSessionData(k));


### PR DESCRIPTION
🎯 **What:** Replaced the `any` type for the `value` parameter in `setSessionData` with `unknown`, and updated the error handling catch block to use a safer type guard (`error instanceof Error`) instead of typecasting to `any`.

💡 **Why:** Relying on `any` bypasses TypeScript's safety mechanisms. Since `JSON.stringify()` safely processes `unknown` values, narrowing the parameter type improves correctness. Similarly, safely guarding the caught error prevents runtime crashes if an unexpected non-Error object is thrown, directly resolving Biome's `noExplicitAny` warnings and improving maintainability.

✅ **Verification:** Verified by successfully running the formatting checks (`biome check`) which passed with zero fixes needed, and ensuring that the full test suite (`pnpm test`), particularly `AuthContext.test.tsx`, continued to pass without regressions.

✨ **Result:** Improved type safety and eliminated two suspicious `any` usages along with their corresponding `biome-ignore` suppression comments, making the authentication context cleaner and more robust.

---
*PR created automatically by Jules for task [5041297174639394442](https://jules.google.com/task/5041297174639394442) started by @guitarbeat*

## Summary by Sourcery

Improve type safety in session storage handling within AuthContext.

Enhancements:
- Restrict setSessionData value parameter to unknown instead of any for safer typing.
- Harden error handling around sessionStorage quota errors by using an Error type guard instead of any casts.
- Remove biome-ignore suppressions related to explicit any usage in AuthContext.