### PR TITLE
🧪 Add tests for useScrollThreshold hook

### DIFF
--- a/src/hooks/__tests__/useScrollUtils.test.ts
+++ b/src/hooks/__tests__/useScrollUtils.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@testing-library/react";
+import { useScrollThreshold } from "../useScrollUtils";
+
+describe("useScrollUtils", () => {
+  beforeAll(() => {
+    let scrollY = 0;
+    Object.defineProperty(window, "scrollY", {
+      get: () => scrollY,
+      set: (val) => {
+        scrollY = val;
+      },
+      configurable: true,
+    });
+  });
+
+  beforeEach(() => {
+    window.scrollY = 0; // RESET for each test!
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  describe("useScrollThreshold", () => {
+    it("should return false initially when scrollY is below threshold", () => {
+      window.scrollY = 0;
+      const { result } = renderHook(() => useScrollThreshold(300, 100));
+      expect(result.current).toBe(false);
+    });
+
+    it("should return true initially when scrollY is above threshold", () => {
+      window.scrollY = 400;
+      const { result } = renderHook(() => useScrollThreshold(300, 100));
+      expect(result.current).toBe(true);
+    });
+
+    it("should update value on scroll after throttle time", () => {
+      const { result } = renderHook(() => useScrollThreshold(300, 100));
+      expect(result.current).toBe(false);
+
+      act(() => {
+        window.scrollY = 400;
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(false);
+
+      act(() => {
+        jest.advanceTimersByTime(150);
+      });
+
+      expect(result.current).toBe(true);
+    });
+
+    it("should remove event listener on unmount", () => {
+      const addEventListenerSpy = jest.spyOn(window, "addEventListener");
+      const removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
+
+      const { unmount } = renderHook(() => useScrollThreshold(300, 100));
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+        { passive: true },
+      );
+
+      unmount();
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+      );
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `useScrollThreshold` hook lacked unit tests, creating a gap in coverage for scroll event handling logic.

📊 **Coverage:** What scenarios are now tested
We added comprehensive test cases covering:
- Initial state verification for scroll positions below the threshold.
- Initial state verification for scroll positions above the threshold.
- Proper throttled updates using `jest.useFakeTimers` and `act`.
- Verification of the cleanup of event listeners when the component unmounts.

✨ **Result:** The improvement in test coverage
The test coverage for `src/hooks/useScrollUtils.ts` is significantly improved, adding deterministic coverage without introducing flaky behaviors and ensuring scroll detection logic functions safely across refactors.

---
*PR created automatically by Jules for task [636322338524588307](https://jules.google.com/task/636322338524588307) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add hook tests covering initial state below and above the scroll threshold, throttled scroll updates, and cleanup of scroll event listeners on unmount.