### PR TITLE
🧪 Add tests for useScrollUtils hooks

### DIFF
--- a/src/hooks/__tests__/useScrollUtils.test.ts
+++ b/src/hooks/__tests__/useScrollUtils.test.ts
@@ -1,0 +1,179 @@
+import { act, renderHook } from "@testing-library/react";
+import { useScrollPosition, useScrollThreshold } from "../useScrollUtils";
+
+describe("useScrollUtils", () => {
+  beforeEach(() => {
+    // Reset window.scrollY before each test
+    Object.defineProperty(window, "scrollY", {
+      value: 0,
+      writable: true,
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  describe("useScrollPosition", () => {
+    it("should return initial scroll position of 0", () => {
+      const { result } = renderHook(() => useScrollPosition());
+      expect(result.current).toBe(0);
+    });
+
+    it("should update scroll position when window scrolls", () => {
+      const { result } = renderHook(() => useScrollPosition(16));
+
+      // Simulate scroll
+      act(() => {
+        window.scrollY = 100;
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      // Initially it should still be 0 because it's throttled
+      expect(result.current).toBe(0);
+
+      // Fast forward time
+      act(() => {
+        jest.advanceTimersByTime(16);
+      });
+
+      expect(result.current).toBe(100);
+    });
+
+    it("should throttle scroll events", () => {
+      const { result } = renderHook(() => useScrollPosition(100));
+
+      // 1st scroll
+      act(() => {
+        window.scrollY = 50;
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(0);
+
+      // 2nd scroll immediately after
+      act(() => {
+        window.scrollY = 150;
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      // advance halfway
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      expect(result.current).toBe(0);
+
+      // advance fully
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+
+      expect(result.current).toBe(150);
+    });
+
+    it("should clean up event listener on unmount", () => {
+      const removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
+      const { unmount } = renderHook(() => useScrollPosition());
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+      );
+
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+
+  describe("useScrollThreshold", () => {
+    it("should return false initially if scroll is below threshold", () => {
+      const { result } = renderHook(() => useScrollThreshold(300, 100));
+      expect(result.current).toBe(false);
+    });
+
+    it("should return true initially if scroll is above threshold", () => {
+      window.scrollY = 400;
+      const { result } = renderHook(() => useScrollThreshold(300, 100));
+      expect(result.current).toBe(true);
+    });
+
+    it("should update when scroll crosses threshold", () => {
+      const { result } = renderHook(() => useScrollThreshold(300, 100));
+
+      expect(result.current).toBe(false);
+
+      // Scroll just below threshold
+      act(() => {
+        window.scrollY = 300;
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(result.current).toBe(false);
+
+      // Scroll above threshold
+      act(() => {
+        window.scrollY = 301;
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(result.current).toBe(true);
+
+      // Scroll back below threshold
+      act(() => {
+        window.scrollY = 299;
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("should throttle scroll checks", () => {
+      const { result } = renderHook(() => useScrollThreshold(300, 100));
+
+      act(() => {
+        window.scrollY = 400;
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      // Before throttle elapsed
+      expect(result.current).toBe(false);
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+      expect(result.current).toBe(false);
+
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("should clean up event listener on unmount", () => {
+      const removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
+      const { unmount } = renderHook(() => useScrollThreshold());
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+      );
+
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `useScrollPosition` and `useScrollThreshold` hooks in `useScrollUtils.ts` lacked test coverage, which left their throttling and state update logic vulnerable to regressions. Added comprehensive tests to `src/hooks/__tests__/useScrollUtils.test.ts`.

📊 **Coverage:** Covered all standard edge cases including: initial position states, proper scroll event handling, logic validation using Jest fake timers to test `throttleMs` configuration, and proper unmounting behavior where event listeners are removed cleanly. It also implicitly covers the internal `useThrottledScroll` function.

✨ **Result:** Test coverage for `src/hooks/useScrollUtils.ts` is dramatically improved. 9 new test suites ensure the scrolling utilities are robust and protected against future bugs.

---
*PR created automatically by Jules for task [1443510479710823405](https://jules.google.com/task/1443510479710823405) started by @guitarbeat*