### PR TITLE
🔒 Fix ReDoS vulnerability in CORS wildcard matching

### DIFF
--- a/src/server/apiCors.js
+++ b/src/server/apiCors.js
@@ -34,8 +34,8 @@ function buildCorsConfig(env = process.env) {
 
   for (const part of parts) {
     if (part.includes("*")) {
-      const escaped = part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regexStr = `^${escaped.replace(/\\\*/g, "[a-zA-Z0-9-]+")}$`;
+      const escaped = part.replace(/[.*+?^$\{}()|[\]\\]/g, "\\$&");
+      const regexStr = `^${escaped.replace(/\\\*/g, "[a-zA-Z0-9-]{1,63}")}$`;
       regexes.push(new RegExp(regexStr));
     } else {
       exact.push(part);


### PR DESCRIPTION
🎯 **What**
Fixed a Regular Expression Denial of Service (ReDoS) vulnerability in the CORS origin matching configuration within `src/server/apiCors.js`.

⚠️ **Risk**
The previous implementation dynamically constructed regular expressions from the `ALLOWED_ORIGINS` environment variable by converting wildcard `*` tokens into unbounded quantifiers (`[a-zA-Z0-9-]+`). A poorly configured environment variable containing alternating wildcards (e.g., `*a*a*`) would lead to catastrophic exponential backtracking, allowing an attacker to hang the server and exhaust resources with specifically crafted origin headers.

🛡️ **Solution**
Strictly bounded the wildcard substitution by replacing the unbounded `+` quantifier with `{1,63}` (`[a-zA-Z0-9-]{1,63}`). This safely bounds the matching engine since a single DNS domain label cannot legally exceed 63 characters (per RFC 1035), completely neutralizing the exponential backtracking risk without breaking legitimate wildcard origins (including non-HTTP protocols like `chrome-extension://`).

---
*PR created automatically by Jules for task [13475191245146849576](https://jules.google.com/task/13475191245146849576) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Prevent catastrophic backtracking in CORS origin regexes by bounding wildcard domain label length to valid DNS limits.