### PR TITLE
⚙️ Improve GitHub Actions: safer CI caching and check-only Biome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,45 +5,41 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9.15.9
-          
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-          
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-            
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        
+
       - name: Run linter
         run: pnpm run lint
-        
+
       - name: Run tests
         run: pnpm test
-        
+
       - name: Build project
         run: pnpm run build:dev

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,49 +5,56 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   biome:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9.15.9
-          
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        
+
       - name: Run Biome
-        run: pnpm exec biome check --write
-        
+        run: pnpm exec biome check
+
   typescript:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9.15.9
-          
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        
+
       - name: TypeScript Check
         run: pnpm exec tsc --noEmit


### PR DESCRIPTION
## Summary

- [x] Add least-privilege workflow permissions and concurrency controls
- [x] Use setup-node’s pnpm cache instead of manual store caching
- [x] Run Biome in check-only mode

## Validation

- [x] Workflow YAML parses successfully
- [ ] Confirm workflow runs pass after merge

## Summary by Sourcery

Tighten GitHub Actions CI workflows with least-privilege permissions, safer concurrency, improved pnpm caching, and non-mutating Biome checks.

Enhancements:
- Restrict repository permissions for CI and code-quality workflows to read-only contents access.
- Add concurrency groups with cancel-in-progress to avoid overlapping workflow runs on the same ref.
- Switch CI pnpm dependency caching to use setup-node's built-in pnpm cache tied to the lockfile.
- Update the Biome workflow to run in check-only mode without writing changes.