### PR TITLE
Fix woods.engineer www/apex asset redirect loop

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -32,17 +32,6 @@
       ],
       "destination": "https://woods.engineer/:path*",
       "permanent": true
-    },
-    {
-      "source": "/:path*",
-      "has": [
-        {
-          "type": "host",
-          "value": "www.woods.engineer"
-        }
-      ],
-      "destination": "https://woods.engineer/:path*",
-      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Removes the `www.woods.engineer` → apex redirect from `vercel.json`.
- Vercel already redirects apex → www, so the reverse hop put `/assets/*` in a 307/308 loop and left production JS unloadable after the Proof release.
- Unblocks smoke-testing Proof on https://www.woods.engineer.

## Test plan
- [ ] Confirm `https://www.woods.engineer/assets/<index>.js` returns 200 (no redirect to apex)
- [ ] Confirm `https://woods.engineer/` still lands on www
- [ ] Locked visit: no Proof, no spritesheet request
- [ ] Unlocked visit: Proof mounts at bottom-right after loader exits
- [ ] Desktop 208px / mobile 160px sizing


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Deployment:
- Update vercel.json domain redirects so www.woods.engineer no longer redirects to the apex domain, preventing loops with Vercel’s apex→www redirect.