### PR TITLE
Fix www/apex asset redirect loop

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -32,17 +32,6 @@
       ],
       "destination": "https://woods.engineer/:path*",
       "permanent": true
-    },
-    {
-      "source": "/:path*",
-      "has": [
-        {
-          "type": "host",
-          "value": "www.woods.engineer"
-        }
-      ],
-      "destination": "https://woods.engineer/:path*",
-      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Remove the `www.woods.engineer` → `woods.engineer` redirect from `vercel.json`.
- Vercel’s domain settings already redirect apex → www, and the competing rules produced a 307/308 loop that prevented `/assets/*.js` from loading on production.

## Test plan
- [ ] `curl -sI https://www.woods.engineer/assets/<index>.js` returns 200 (not a redirect loop)
- [ ] `https://www.woods.engineer/` loads the React app
- [ ] Locked session does not fetch Proof spritesheet
- [ ] Unlocked session mounts Proof companion


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Build:
- Update vercel.json routing configuration to remove the custom www-to-apex redirect that conflicted with Vercel’s domain settings.