### PR TITLE
Document Proof and simplify mount gating

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Verify Proof vendor manifest
         run: pnpm run verify:proof
 
+      - name: Test Proof vendor verifier
+        run: pnpm run test:proof-vendor
+
       - name: Verify HTML entry sync
         run: pnpm run sync:html:check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Proof companion on unlocked routes via vendored `@aarons-sprites/proof-react` `0.2.0`
+- `SiteProof` wrapper (208px desktop / 160px mobile, bottom-right, 72px inset)
+- Read-only vendor manifest verifier (`pnpm verify:proof`, `pnpm test:proof-vendor`)
+- Site z-index token `--z-index-proof` (`35`)
+
+### Fixed
+
+- `www.woods.engineer` ↔ apex asset redirect loop that blocked production JS
+
 ## [0.1.1] - 2026-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The website is built with React, Sass, and modern JavaScript. Its layout emphasi
 - About section with a concise biography and supplemental media embeds
 - Projects grid that spotlights selected work with dynamic tag styling
 - Work timeline outlining professional experience and key achievements
+- Proof companion on unlocked routes (lazy-loaded atlas; see [docs/PROOF.md](docs/PROOF.md))
 - Back to top button and sticky navigation for smooth browsing
 
 ## How to Use
@@ -29,6 +30,7 @@ Detailed technical documentation, design specifications, and migration plans are
 - [Architecture](docs/ARCHITECTURE.md) – Dev/build flows, app layers, Notion and Sass maps.
 - [Notion Integration](docs/NOTION_INTEGRATION.md) – Comprehensive guide for the Google Sheets to Notion migration.
 - [Matrix Component](docs/MATRIX_COMPONENT.md) – Easter-egg authentication effect and usage notes.
+- [Proof Companion](docs/PROOF.md) – Unlock gating, sizing, vendor sync, and manifest verification.
 - [Code Audit Report](docs/CODE_AUDIT_REPORT.md) – Security and quality analysis of the codebase.
 - [Development Notes](docs/DEVELOPMENT_NOTES.md) – Technical notes and refactoring opportunities.
 - [Archive](docs/archive/) – Historical implementation debates and analyses.
@@ -50,7 +52,8 @@ Detailed technical documentation, design specifications, and migration plans are
 | `/docs`                    | Technical documentation and archives | `NOTION_INTEGRATION.md`, `DEVELOPMENT_NOTES.md`        |
 | `/src`                     | TypeScript/React application source  | `App.tsx`, `index.tsx`                                 |
 | `/src/components/content`  | Page sections                        | `About/`, `Header/`, `NavBar/`, `Projects/`, `Work/`   |
-| `/src/components/effects`  | Visual effects                       | `Matrix/`, `Moire/`, `Blur/`, `Loading/`               |
+| `/src/components/effects`  | Visual effects                       | `Matrix/`, `Proof/`, `Moire/`, `Blur/`, `Loading/`     |
+| `/src/vendor/proof`        | Vendored Proof React source + atlas  | `.proof-vendor.json`, `ProofCompanion.tsx`             |
 | `/src/server/notion`       | Notion content API modules           | `api.js`, `snapshot.js`, `validate.js`                 |
 | `/src/hooks`               | Custom React hooks                   | `useMobileDetection.ts`, `useScrollUtils.ts`           |
 | `/src/utils`               | Shared utilities                     | `commonUtils.ts`, `audioUtils.ts`, `colorUtils.ts`     |
@@ -75,3 +78,5 @@ See [AGENTS.md](AGENTS.md) for the full command reference.
 ## Component Documentation
 
 See [docs/MATRIX_COMPONENT.md](docs/MATRIX_COMPONENT.md) for the Matrix easter-egg effect (`src/components/effects/Matrix/`).
+
+See [docs/PROOF.md](docs/PROOF.md) for the Proof companion (`src/components/effects/Proof/`, `src/vendor/proof/`).

--- a/docs/PROOF.md
+++ b/docs/PROOF.md
@@ -1,0 +1,70 @@
+# Proof Companion
+
+Proof is the site companion on unlocked routes. Source is vendored from
+`@aarons-sprites/proof-react` into [`src/vendor/proof/`](../src/vendor/proof/) —
+private, not an npm install.
+
+## Mount gates
+
+`App` lazy-loads [`SiteProof`](../src/components/effects/Proof/SiteProof.tsx)
+only when all of these are true:
+
+1. The visitor is unlocked (`AuthContext`)
+2. The initial loader has finished exiting
+3. The Matrix overlay is closed
+
+Locked visitors never download the atlas or the `SiteProof` chunk. While Matrix
+is open, Proof stays unmounted even if the session is already unlocked.
+
+Use `canMountSiteProof` from `siteProofMount.ts` for the shared predicate.
+
+## Site configuration
+
+| Setting | Value |
+| --- | --- |
+| Desktop size | `208` px |
+| Mobile size | `160` px |
+| Placement | `bottom-right` |
+| Inset | `72` px |
+| Storage key | `woods-engineer-proof-position` |
+| Label | `Proof, site companion` |
+| Stacking | `--z-index-proof` (`35`), below nav, Matrix, loaders, modals, and the custom cursor |
+
+`SiteProof` owns those knobs. Do not edit files under `src/vendor/proof/`;
+re-vendor from `aarons-sprites` instead.
+
+## Vendor sync
+
+From an `aarons-sprites` checkout (after building Proof):
+
+```bash
+npm run proof:vendor -- \
+  --target /absolute/path/to/personal-website/src/vendor/proof
+```
+
+Check without writing:
+
+```bash
+npm run proof:vendor -- \
+  --target /absolute/path/to/personal-website/src/vendor/proof \
+  --check
+```
+
+The export writes typed source, the atlas, and `.proof-vendor.json` with
+per-file SHA-256 digests. Later syncs refuse consumer edits, missing files, or
+unexpected files. Keep site wrappers (like `SiteProof`) outside that directory.
+
+## Verification
+
+```bash
+pnpm run verify:proof          # read-only manifest check
+pnpm run test:proof-vendor     # fixture tests for clean / missing / edited / stale / extra
+```
+
+Code Quality CI runs both. Biome ignores `src/vendor/**` so formatting cannot
+invalidate the hashes.
+
+## Related
+
+- Matrix unlock flow: [MATRIX_COMPONENT.md](MATRIX_COMPONENT.md)
+- Vendored package version: see `src/vendor/proof/.proof-vendor.json`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { NAV_ITEMS } from "@/components/Core/constants";
 import { ContentUnavailableState } from "@/components/Core/SiteLayout";
 import LoadingSequence from "@/components/effects/Loading/LoadingSequence";
 import { AuthProvider, useAuth } from "@/components/effects/Matrix/AuthContext";
+import { canMountSiteProof } from "@/components/effects/Proof/siteProofMount";
 import { NotionProvider, useNotion } from "@/contexts/NotionContext";
 import { useMatrixActivation } from "@/hooks/useMatrixActivation";
 import { useScrollMode } from "@/hooks/useScrollMode";
@@ -55,7 +56,11 @@ function AppContent() {
   const isBackgroundVisible = true;
   const canRevealInitialLoader =
     isInitialLoaderVisible && hasMinimumLoaderDurationElapsed;
-  const shouldMountProof = isUnlocked && !isInitialLoaderVisible && !showMatrix;
+  const shouldMountProof = canMountSiteProof({
+    isUnlocked,
+    isInitialLoaderVisible,
+    showMatrix,
+  });
 
   const handleInitialLoaderExit = useCallback(() => {
     setIsInitialLoaderVisible(false);
@@ -80,11 +85,7 @@ function AppContent() {
       ) : null}
       {shouldMountProof ? (
         <Suspense fallback={null}>
-          <SiteProof
-            isUnlocked={isUnlocked}
-            isInitialLoaderVisible={isInitialLoaderVisible}
-            showMatrix={showMatrix}
-          />
+          <SiteProof />
         </Suspense>
       ) : null}
       {showUnavailableState ? (

--- a/src/components/effects/Proof/SiteProof.test.tsx
+++ b/src/components/effects/Proof/SiteProof.test.tsx
@@ -39,6 +39,40 @@ jest.mock("@/vendor/proof", () => {
 });
 
 import { SiteProof } from "./SiteProof";
+import { canMountSiteProof } from "./siteProofMount";
+
+describe("canMountSiteProof", () => {
+  it("requires unlock, exited loader, and closed Matrix", () => {
+    expect(
+      canMountSiteProof({
+        isUnlocked: true,
+        isInitialLoaderVisible: false,
+        showMatrix: false,
+      }),
+    ).toBe(true);
+    expect(
+      canMountSiteProof({
+        isUnlocked: false,
+        isInitialLoaderVisible: false,
+        showMatrix: false,
+      }),
+    ).toBe(false);
+    expect(
+      canMountSiteProof({
+        isUnlocked: true,
+        isInitialLoaderVisible: true,
+        showMatrix: false,
+      }),
+    ).toBe(false);
+    expect(
+      canMountSiteProof({
+        isUnlocked: true,
+        isInitialLoaderVisible: false,
+        showMatrix: true,
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("SiteProof", () => {
   beforeEach(() => {
@@ -47,45 +81,8 @@ describe("SiteProof", () => {
     mockUseMobileDetection.mockReturnValue({ isMobile: false });
   });
 
-  it("does not mount while locked", () => {
-    const { container } = render(
-      <SiteProof
-        isUnlocked={false}
-        isInitialLoaderVisible={false}
-        showMatrix={false}
-      />,
-    );
-
-    expect(container).toBeEmptyDOMElement();
-    expect(mockProofCompanion).not.toHaveBeenCalled();
-  });
-
-  it("does not mount while the initial loader is visible", () => {
-    const { container } = render(
-      <SiteProof isUnlocked isInitialLoaderVisible showMatrix={false} />,
-    );
-
-    expect(container).toBeEmptyDOMElement();
-    expect(mockProofCompanion).not.toHaveBeenCalled();
-  });
-
-  it("does not mount while Matrix is open", () => {
-    const { container } = render(
-      <SiteProof isUnlocked isInitialLoaderVisible={false} showMatrix />,
-    );
-
-    expect(container).toBeEmptyDOMElement();
-    expect(mockProofCompanion).not.toHaveBeenCalled();
-  });
-
-  it("mounts unlocked Proof at desktop size after loader and Matrix exit", () => {
-    render(
-      <SiteProof
-        isUnlocked
-        isInitialLoaderVisible={false}
-        showMatrix={false}
-      />,
-    );
+  it("mounts Proof at desktop size with site stacking and persistence", () => {
+    render(<SiteProof />);
 
     const companion = screen.getByTestId("proof-companion");
     expect(companion).toHaveAttribute("data-size", "208");
@@ -104,13 +101,7 @@ describe("SiteProof", () => {
   it("uses the mobile size on narrow viewports", () => {
     mockUseMobileDetection.mockReturnValue({ isMobile: true });
 
-    render(
-      <SiteProof
-        isUnlocked
-        isInitialLoaderVisible={false}
-        showMatrix={false}
-      />,
-    );
+    render(<SiteProof />);
 
     expect(screen.getByTestId("proof-companion")).toHaveAttribute(
       "data-size",

--- a/src/components/effects/Proof/SiteProof.tsx
+++ b/src/components/effects/Proof/SiteProof.tsx
@@ -6,22 +6,12 @@ const PROOF_INSET = 72;
 const PROOF_DESKTOP_SIZE = 208;
 const PROOF_MOBILE_SIZE = 160;
 
-export type SiteProofProps = {
-  isUnlocked: boolean;
-  isInitialLoaderVisible: boolean;
-  showMatrix: boolean;
-};
-
-export function SiteProof({
-  isUnlocked,
-  isInitialLoaderVisible,
-  showMatrix,
-}: SiteProofProps) {
+/**
+ * Site-owned Proof wrapper. Mount only after `canMountSiteProof` is true so
+ * locked visitors never download the atlas.
+ */
+export function SiteProof() {
   const { isMobile } = useMobileDetection();
-
-  if (!isUnlocked || isInitialLoaderVisible || showMatrix) {
-    return null;
-  }
 
   return (
     <ProofCompanion

--- a/src/components/effects/Proof/siteProofMount.ts
+++ b/src/components/effects/Proof/siteProofMount.ts
@@ -1,0 +1,14 @@
+export type SiteProofMountState = {
+  isUnlocked: boolean;
+  isInitialLoaderVisible: boolean;
+  showMatrix: boolean;
+};
+
+/** Shared App gate: unlock + loader exited + Matrix closed. */
+export function canMountSiteProof({
+  isUnlocked,
+  isInitialLoaderVisible,
+  showMatrix,
+}: SiteProofMountState): boolean {
+  return isUnlocked && !isInitialLoaderVisible && !showMatrix;
+}


### PR DESCRIPTION
## Summary
- Add `docs/PROOF.md` and README/CHANGELOG coverage for the shipped companion
- Extract `canMountSiteProof` and drop redundant SiteProof gate props (App owns lazy mount)
- Run `pnpm test:proof-vendor` in Code Quality beside `verify:proof`

## Test plan
- [ ] `pnpm exec tsc --noEmit`
- [ ] `pnpm test -- --testPathPattern=SiteProof --watchAll=false`
- [ ] `pnpm run verify:proof && pnpm run test:proof-vendor`
- [ ] Confirm locked visitors still do not download SiteProof/spritesheet
- [ ] Confirm unlocked desktop/mobile sizing still 208/160 with 72px inset

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Document the Proof companion integration, centralize the mount gating logic, and adjust the app and tests to rely on the shared predicate while wiring Proof verification into CI.

New Features:
- Introduce a dedicated SiteProof wrapper component that renders the Proof companion with site-specific sizing and placement.
- Add canMountSiteProof helper to encapsulate the unlock/loader/Matrix gating logic for the Proof companion.
- Add PROOF.md documentation describing Proof mount rules, configuration, vendor sync flow, and verification commands.

Bug Fixes:
- Clarify and enforce mount gating so locked visitors and Matrix sessions do not load the Proof atlas, preventing unintended asset downloads.

Enhancements:
- Refactor App to use the shared canMountSiteProof predicate instead of inline gating logic before mounting SiteProof.
- Simplify SiteProof to rely solely on app-level gating, removing now-redundant props and inline gate checks.
- Update tests for SiteProof to cover the new gating helper and focus on sizing and stacking behavior.
- Update README and changelog entries to describe the Proof companion, its docs, and vendor layout.

CI:
- Extend the code-quality workflow to run the Proof vendor verifier tests alongside the existing manifest verification step.

Documentation:
- Add PROOF.md to document Proof integration details, gating, vendor sync, and verification, and link it from the README and component docs.
- Update project documentation structure to include the Proof effect and vendored Proof directory in the described layout.

Tests:
- Add unit tests for canMountSiteProof to validate unlock, loader, and Matrix gating behavior.