### PR TITLE
⚙️ Improve GitHub Actions: bounded, least-privilege CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   biome:
     runs-on: ubuntu-latest
+      timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -47,6 +48,7 @@ jobs:
 
   typescript:
     runs-on: ubuntu-latest
+      timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,12 +9,15 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.actor == 'dependabot[bot]'
     
     steps:
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Enable auto-merge for Dependabot PRs
         if: |

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,9 +11,17 @@ on:
       - '.lighthouserc.json'
       - 'index.html'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: lighthouse-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lighthouse-ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
- [x] Least-privilege permissions for Lighthouse CI
- [x] Concurrency and timeouts for CI jobs
- [x] Deterministic installs retained with pnpm lockfile
- [x] Dependabot metadata token and actor guard retained

No production infrastructure or secrets are required.

## Summary by Sourcery

Tighten and bound GitHub Actions CI workflows with least-privilege permissions, explicit concurrency, and job timeouts.

CI:
- Restrict Lighthouse workflow permissions to read-only repository contents and add concurrency controls to avoid overlapping runs.
- Introduce explicit timeout limits for Lighthouse, Dependabot auto-merge, code quality, and main CI jobs.
- Configure Dependabot metadata step to use the GitHub token explicitly for fetch-metadata.