### PR TITLE
🧹 Rephrase Printful API comment in vite.config.ts to resolve false positive

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -171,7 +171,7 @@ export default defineConfig(({ mode }) => {
       ),
       "process.env.REACT_APP_API_BASE": JSON.stringify(apiBase),
       "process.env.VERCEL": JSON.stringify(process.env.VERCEL || ""),
-      // Security Fix: Printful API keys removed to prevent client-side exposure
+      // Printful API keys are explicitly initialized to empty strings to prevent client-side exposure
       "process.env.REACT_APP_PRINTFUL_API_KEY": JSON.stringify(""),
       "process.env.REACT_APP_PRINTFUL_STORE_ID": JSON.stringify(""),
       "process.env.REACT_APP_GIT_COMMIT_HASH": JSON.stringify(


### PR DESCRIPTION
🎯 **What**
Rephrased the informational comment regarding Printful API keys in `vite.config.ts` to remove the keyword "Fix". 

💡 **Why**
The previous comment "Security Fix: Printful API keys removed..." was being flagged by the automated task scanner as an actionable, pending task because of the word "Fix", even though the actual implementation (initializing the keys to empty strings) had already been properly addressed. Rephrasing the comment prevents this false positive while keeping the necessary context.

✅ **Verification**
Verified that only the comment in `vite.config.ts` was modified using `git diff`. Re-ran the test suite with `pnpm test` to ensure the change caused no regressions (all tests passed).

✨ **Result**
The code scanner will no longer flag this comment as a pending task, and the environment variables configuration remains secure and correctly documented.

---
*PR created automatically by Jules for task [17685228545022444015](https://jules.google.com/task/17685228545022444015) started by @guitarbeat*

## Summary by Sourcery

Build:
- Update vite.config.ts comment about Printful API key handling without changing runtime behavior.