### PR TITLE
🔒 Fix command injection in branch cleanup analysis script

### DIFF
--- a/scripts/archive/branch-cleanup-analyze.js
+++ b/scripts/archive/branch-cleanup-analyze.js
@@ -1,5 +1,14 @@
 #!/usr/bin/env node
-const { sh } = require("../lib/exec.cjs");
+const { execFileSync } = require("node:child_process");
+const { sh, ROOT } = require("../lib/exec.cjs");
+
+function git(args) {
+  return execFileSync("git", args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
 
 const KEEP = new Set(["main", "gh-pages"]);
 
@@ -23,7 +32,7 @@ for (const branch of branches) {
 
   let merged = false;
   try {
-    sh(`git merge-base --is-ancestor "origin/${branch}" origin/main`);
+    git(["merge-base", "--is-ancestor", `origin/${branch}`, "origin/main"]);
     merged = true;
   } catch {
     merged = false;
@@ -34,13 +43,13 @@ for (const branch of branches) {
   let diffStat = "";
   try {
     ahead = Number(
-      sh(`git rev-list --count origin/main..origin/${branch}`) || 0,
+      git(["rev-list", "--count", `origin/main..origin/${branch}`]) || 0,
     );
     behind = Number(
-      sh(`git rev-list --count origin/${branch}..origin/main`) || 0,
+      git(["rev-list", "--count", `origin/${branch}..origin/main`]) || 0,
     );
     if (ahead > 0) {
-      diffStat = sh(`git diff --shortstat origin/main...origin/${branch}`);
+      diffStat = git(["diff", "--shortstat", `origin/main...origin/${branch}`]);
     }
   } catch (e) {
     results.push({


### PR DESCRIPTION
🎯 **What**
Fixed a command injection vulnerability in `scripts/archive/branch-cleanup-analyze.js`.

⚠️ **Risk**
The script previously concatenated an unescaped `branch` variable directly into shell commands (`sh(\`git ... ${branch}\`)`). If a malicious or malformed branch name were fetched and processed, it could execute arbitrary shell commands on the system running the script, leading to full system compromise.

🛡️ **Solution**
Replaced the shell-based `sh()` calls with a new `git()` wrapper function that utilizes `node:child_process`'s `execFileSync`. By passing the arguments as an array (`shell: false` default), we bypass shell evaluation entirely, safely passing the branch name as a literal string to the git binary.

---
*PR created automatically by Jules for task [12194598667424232300](https://jules.google.com/task/12194598667424232300) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Eliminate command injection risk in scripts/archive/branch-cleanup-analyze.js by avoiding shell-evaluated git commands.