### PR TITLE
🧹 Refactor UnlockProvider to use custom hook for logic separation

### DIFF
--- a/src/components/effects/Matrix/UnlockContext.tsx
+++ b/src/components/effects/Matrix/UnlockContext.tsx
@@ -132,9 +132,7 @@ const readUnlockStateFromStorage = () => {
   return unlockState;
 };
 
-export const UnlockProvider = ({ children }: { children: React.ReactNode }) => {
-  const { isMobile } = useMobileDetection();
-
+export const useUnlockState = (isMobile: boolean) => {
   const [unlockState, setUnlockState] = useState<Record<string, boolean>>(
     readUnlockStateFromStorage,
   );
@@ -255,29 +253,40 @@ export const UnlockProvider = ({ children }: { children: React.ReactNode }) => {
     return isUnlocked;
   }, [isMobile, isMobileUnlocked, isUnlocked]);
 
+  return useMemo(
+    () => ({
+      isUnlocked,
+      isMobileUnlocked,
+      toolsAccessible,
+      completeHack,
+      showHackCompleteFeedback,
+      logout,
+    }),
+    [
+      isUnlocked,
+      isMobileUnlocked,
+      toolsAccessible,
+      completeHack,
+      showHackCompleteFeedback,
+      logout,
+    ],
+  );
+};
+
+export const UnlockProvider = ({ children }: { children: React.ReactNode }) => {
+  const { isMobile } = useMobileDetection();
+  const unlockState = useUnlockState(isMobile);
+
+  const contextValue = useMemo(
+    () => ({
+      ...unlockState,
+      isMobile,
+    }),
+    [unlockState, isMobile],
+  );
+
   return (
-    <UnlockContext.Provider
-      value={useMemo(
-        () => ({
-          isUnlocked,
-          isMobileUnlocked,
-          toolsAccessible,
-          completeHack,
-          showHackCompleteFeedback,
-          logout,
-          isMobile,
-        }),
-        [
-          isUnlocked,
-          isMobileUnlocked,
-          toolsAccessible,
-          completeHack,
-          showHackCompleteFeedback,
-          logout,
-          isMobile,
-        ],
-      )}
-    >
+    <UnlockContext.Provider value={contextValue}>
       {children}
     </UnlockContext.Provider>
   );


### PR DESCRIPTION
🎯 **What:** The overly long `UnlockProvider` component (previously incorrectly labelled as `AuthContext.tsx` in task prompt) has been refactored by extracting its state management and side effects into a custom `useUnlockState` hook.
💡 **Why:** This drastically improves the maintainability and readability of `UnlockContext.tsx`. By decoupling the complex state and lifecycle management (such as timeouts, device-specific unlock states, and `sessionStorage` handlers) into a standalone custom hook, the provider component becomes simpler, adhering more closely to the single responsibility principle.
✅ **Verification:** I successfully verified the functionality works by running the entire React unit test suite with `pnpm test`, ensuring that context consumers were not negatively impacted (especially checking that `UnlockContext.test.tsx` passes). I also successfully passed the `npx @biomejs/biome check` to ensure correctness and exhaustive dependency mapping is strictly applied. 
✨ **Result:** A more readable, maintainable, and safely-memoized `UnlockProvider` component implementation.

---
*PR created automatically by Jules for task [2657107470254177051](https://jules.google.com/task/2657107470254177051) started by @guitarbeat*

## Summary by Sourcery

Extract UnlockProvider state and side-effect logic into a reusable useUnlockState hook and simplify the provider to consume the hook output.

Enhancements:
- Introduce a useUnlockState custom hook encapsulating unlock-related state, side effects, and derived values.
- Refactor UnlockProvider to delegate logic to useUnlockState and expose a memoized context value including isMobile.