### PR TITLE
🔒 Fix shell command injection in branch cleanup analysis script

### DIFF
--- a/scripts/archive/branch-cleanup-analyze.js
+++ b/scripts/archive/branch-cleanup-analyze.js
@@ -3,6 +3,8 @@ const { sh } = require("../lib/exec.cjs");
 
 const KEEP = new Set(["main", "gh-pages"]);
 
+const escapeShell = (arg) => "'" + arg.replace(/'/g, "'\\''") + "'";
+
 const branches = sh(
   'gh api "repos/guitarbeat/personal-website/branches?per_page=100" --paginate -q "[.[].name][]"',
 )
@@ -23,7 +25,7 @@ for (const branch of branches) {
 
   let merged = false;
   try {
-    sh(`git merge-base --is-ancestor "origin/${branch}" origin/main`);
+    sh(`git merge-base --is-ancestor ${escapeShell("origin/" + branch)} origin/main`);
     merged = true;
   } catch {
     merged = false;
@@ -34,13 +36,13 @@ for (const branch of branches) {
   let diffStat = "";
   try {
     ahead = Number(
-      sh(`git rev-list --count origin/main..origin/${branch}`) || 0,
+      sh(`git rev-list --count origin/main..${escapeShell("origin/" + branch)}`) || 0,
     );
     behind = Number(
-      sh(`git rev-list --count origin/${branch}..origin/main`) || 0,
+      sh(`git rev-list --count ${escapeShell("origin/" + branch)}..origin/main`) || 0,
     );
     if (ahead > 0) {
-      diffStat = sh(`git diff --shortstat origin/main...origin/${branch}`);
+      diffStat = sh(`git diff --shortstat origin/main...${escapeShell("origin/" + branch)}`);
     }
   } catch (e) {
     results.push({


### PR DESCRIPTION
🎯 **What:** Fixed a shell command injection vulnerability in `scripts/archive/branch-cleanup-analyze.js` where untrusted input (the `branch` variable) was being directly interpolated into shell commands.
⚠️ **Risk:** If an attacker could somehow influence the branch names (or if a branch was maliciously named in the repository), the unescaped branch name would be executed as arbitrary shell commands, potentially leading to unauthorized access, code execution, or data loss.
🛡️ **Solution:** Added a shell escaping utility function `escapeShell` that safely wraps branch names in single quotes and escapes any inner single quotes (`'\\''`). This ensures the branch names are treated as string literals by the shell, preventing the execution of embedded shell metacharacters.

---
*PR created automatically by Jules for task [7613113197872846975](https://jules.google.com/task/7613113197872846975) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Escape untrusted branch names before passing them to git shell commands in the branch cleanup analysis script to prevent command injection.