### PR TITLE
🔒 fix(scripts): prevent command injection in pr cleanup script

### DIFF
--- a/scripts/archive/pr-cleanup-run.js
+++ b/scripts/archive/pr-cleanup-run.js
@@ -41,6 +41,8 @@ let mergeFail = 0;
 
 for (const entry of winners.merge) {
   const { number, reason } = entry;
+  if (!Number.isInteger(Number(number)))
+    throw new Error(`Invalid PR number: ${number}`);
   process.stderr.write(`Merging #${number}...\n`);
   const result = shTry(
     `gh pr merge ${number} --squash --delete-branch --repo ${REPO}`,
@@ -82,6 +84,8 @@ for (const pr of openPrs) {
       "Closing as part of PR cleanup. Change does not provide sufficient value relative to maintenance cost or overlaps with merged work.";
   }
 
+  if (!Number.isInteger(Number(pr.number)))
+    throw new Error(`Invalid PR number: ${pr.number}`);
   process.stderr.write(`Closing #${pr.number}...\n`);
   const closeResult = shTry(
     `gh pr close ${pr.number} --comment "${comment.replace(/"/g, '\\"')}" --repo ${REPO}`,


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in `scripts/archive/pr-cleanup-run.js` by validating that PR numbers are strict integers before concatenating them into `gh` shell commands.

⚠️ **Risk:** Unvalidated PR numbers from JSON files (`pr-cleanup-winners.json` and `gh pr list` output) were being directly concatenated into `execSync` (`shTry`). If an attacker could influence the contents of these files (e.g., via malicious branch names or PR titles that end up in the JSON), they could inject shell commands like `123; rm -rf /`.

🛡️ **Solution:** Added a strict `!Number.isInteger(Number(number))` check before shell execution. `Number()` is used instead of `parseInt()` because `parseInt()` unsafely ignores trailing characters (e.g., `parseInt("123; ls") === 123`). This ensures that only valid, safe numbers are passed to the `gh` CLI.

---
*PR created automatically by Jules for task [14396679461601863275](https://jules.google.com/task/14396679461601863275) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Reject non-integer PR numbers before constructing gh CLI commands in the PR cleanup script to eliminate a command injection vector.