### PR TITLE
🧪 Test NotionService API fetching

### DIFF
--- a/src/services/notionService.test.ts
+++ b/src/services/notionService.test.ts
@@ -1,0 +1,143 @@
+import { fetchContent } from "./notionService";
+
+describe("fetchContent", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should fetch and return content successfully", async () => {
+    const mockResponse = {
+      data: { test: "data" },
+      meta: { test: "meta" },
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce(mockResponse),
+    });
+
+    const result = await fetchContent();
+    expect(result).toEqual(mockResponse);
+    expect(global.fetch).toHaveBeenCalledWith("/api/content", {
+      method: "GET",
+    });
+  });
+
+  it("should throw error if payload is missing data property", async () => {
+    const mockResponse = {
+      meta: { test: "meta" },
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce(mockResponse),
+    });
+
+    await expect(fetchContent()).rejects.toThrow(
+      "Content API returned an invalid response. Start the Vite dev server with `pnpm start` and open http://localhost:8080 so `/api/content` is available."
+    );
+  });
+
+  it("should throw error if payload is missing meta property", async () => {
+    const mockResponse = {
+      data: { test: "data" },
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce(mockResponse),
+    });
+
+    await expect(fetchContent()).rejects.toThrow(
+      "Content API returned an invalid response. Start the Vite dev server with `pnpm start` and open http://localhost:8080 so `/api/content` is available."
+    );
+  });
+
+  describe("error parsing on failed fetch (!response.ok)", () => {
+    it("should parse nested error.message", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        statusText: "Not Found",
+        json: jest.fn().mockResolvedValueOnce({
+          error: { message: "Nested error message" },
+        }),
+      });
+
+      await expect(fetchContent()).rejects.toThrow(
+        "Nested error message"
+      );
+    });
+
+    it("should parse nested error.failureType", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        statusText: "Not Found",
+        json: jest.fn().mockResolvedValueOnce({
+          error: { failureType: "Nested failure type" },
+        }),
+      });
+
+      await expect(fetchContent()).rejects.toThrow(
+        "Nested failure type"
+      );
+    });
+
+    it("should parse nested error.code", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        statusText: "Not Found",
+        json: jest.fn().mockResolvedValueOnce({
+          error: { code: "NESTED_ERROR_CODE" },
+        }),
+      });
+
+      await expect(fetchContent()).rejects.toThrow(
+        "NESTED_ERROR_CODE"
+      );
+    });
+
+    it("should parse top-level message", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        statusText: "Not Found",
+        json: jest.fn().mockResolvedValueOnce({
+          message: "Top level message",
+        }),
+      });
+
+      await expect(fetchContent()).rejects.toThrow(
+        "Top level message"
+      );
+    });
+
+    it("should fallback to statusText if payload format is unknown", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        statusText: "Fallback Status Text",
+        json: jest.fn().mockResolvedValueOnce({
+          unknownFormat: "something",
+        }),
+      });
+
+      await expect(fetchContent()).rejects.toThrow(
+        "Fallback Status Text"
+      );
+    });
+
+    it("should fallback to statusText if json parsing fails", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        statusText: "JSON Parse Error Status Text",
+        json: jest.fn().mockRejectedValueOnce(new Error("Invalid JSON")),
+      });
+
+      await expect(fetchContent()).rejects.toThrow(
+        "JSON Parse Error Status Text"
+      );
+    });
+  });
+});

--- a/src/services/notionService.ts
+++ b/src/services/notionService.ts
@@ -31,7 +31,7 @@ const parseApiError = (payload: unknown, fallbackMessage: string) => {
   return fallbackMessage;
 };
 
-const fetchContent = async (): Promise<ContentResponse> => {
+export const fetchContent = async (): Promise<ContentResponse> => {
   const response = await fetch(`${API_BASE}/api/content`, {
     method: "GET",
   });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `fetchContent` in `notionService.ts`, ensuring robust test coverage of the API fetching and error parsing logic.

📊 **Coverage:** Scenarios now tested include successful responses, responses missing `data` or `meta` properties, and all variations of error formatting (nested `message`, `failureType`, `code`, top-level `message`, unknown formats, and JSON parsing failures).

✨ **Result:** The improvement in test coverage secures the `fetchContent` logic against regressions, giving confidence in its behavior under varying API responses and error states.

---
*PR created automatically by Jules for task [4452542510824097250](https://jules.google.com/task/4452542510824097250) started by @guitarbeat*

## Summary by Sourcery

Expand test coverage for Notion content fetching and error handling.

Enhancements:
- Export fetchContent from notionService to enable direct testing.

Tests:
- Add unit tests covering successful and invalid content responses from the Notion content API.
- Add tests validating error parsing behavior for various error payload formats and JSON parsing failures.