### PR TITLE
🧹 [Code Health] Extract useProjectFilters from Projects.tsx

### DIFF
--- a/src/components/content/Projects/ProjectCard.tsx
+++ b/src/components/content/Projects/ProjectCard.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { cn } from "@/utils/commonUtils";
+import {
+  DEFAULT_PROJECT_EFFECT,
+  type MoireEffectPreset,
+} from "@/utils/moireEffectPresets";
+import PixelCanvas from "../../effects/PixelCanvas/PixelCanvas";
+
+interface ProjectCardProps {
+  title: string;
+  hook: string;
+  detail: string;
+  slug: string;
+  link?: string | null;
+  keywords: string[];
+  date: string | number | null;
+  image?: string | null;
+  tagColors?: Record<string, string>;
+  primaryTagColor?: string;
+  className?: string;
+  effect?: MoireEffectPreset;
+}
+
+function ProjectCard({
+  title,
+  hook,
+  detail,
+  slug,
+  link,
+  keywords,
+  date,
+  image,
+  tagColors,
+  primaryTagColor,
+  className = "",
+  effect = DEFAULT_PROJECT_EFFECT,
+}: ProjectCardProps) {
+  const [isClicked, setIsClicked] = useState(false);
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (!isClicked) {
+      e.preventDefault();
+      setIsClicked(true);
+    }
+  };
+
+  const _link = link ? (
+    <div className="projects__card__label projects__card__link">Link</div>
+  ) : null;
+
+  return (
+    <a
+      href={link || undefined}
+      target={link ? "_blank" : undefined}
+      rel={link ? "noreferrer" : undefined}
+      className={cn(
+        `projects__card ${className}`.trim(),
+        image && "has-image",
+        isClicked && "is-expanded",
+      )}
+      key={slug}
+      onClick={handleClick}
+    >
+      <PixelCanvas
+        className="projects__card__pixel-canvas"
+        colors={effect.colors}
+        gap={effect.gap}
+        speed={effect.speed}
+      />
+      <div className="projects__card__content">
+        <div className="projects__card__meta">
+          <p className="projects__card__year">{date ?? ""}</p>
+          <div className="projects__card__keywords">
+            {_link}
+            {keywords.map((keyword) => (
+              <div
+                key={keyword}
+                className="projects__card__label"
+                style={{
+                  backgroundColor:
+                    tagColors?.[keyword] ||
+                    primaryTagColor ||
+                    "rgba(255, 255, 255, 0.25)",
+                }}
+              >
+                {keyword}
+              </div>
+            ))}
+          </div>
+        </div>
+        <h3>{title}</h3>
+        <p className="projects__card__hook">{hook}</p>
+        <div
+          className={cn(
+            "projects__card__detail-wrapper",
+            isClicked && "show-text",
+          )}
+        >
+          <div className="projects__card__detail-inner">
+            <p className="projects__card__detail">{detail}</p>
+          </div>
+        </div>
+        {image && (
+          <img
+            src={image}
+            className="project-image"
+            alt="Project"
+            width={16}
+            height={9}
+          />
+        )}
+      </div>
+    </a>
+  );
+}
+
+export default ProjectCard;

--- a/src/components/content/Projects/Projects.tsx
+++ b/src/components/content/Projects/Projects.tsx
@@ -1,195 +1,25 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNotionSectionData } from "@/hooks/useNotionSectionData";
+import { useProjectFilters } from "@/hooks/useProjectFilters";
 import type { NotionData } from "@/types/content";
-import { generateTagColors } from "@/utils/colorUtils";
 import { cn } from "@/utils/commonUtils";
-import {
-  createProjectEffect,
-  DEFAULT_PROJECT_EFFECT,
-  type MoireEffectPreset,
-} from "@/utils/moireEffectPresets";
-import { reconcileProjectFilters } from "@/utils/reconcileProjectFilters";
-import PixelCanvas from "../../effects/PixelCanvas/PixelCanvas";
+import { createProjectEffect } from "@/utils/moireEffectPresets";
 import { NotionSectionSkeleton } from "../shared/NotionSectionSkeleton";
+import ProjectCard from "./ProjectCard";
 
-interface ProjectCardProps {
-  title: string;
-  hook: string;
-  detail: string;
-  slug: string;
-  link?: string | null;
-  keywords: string[];
-  date: string | number | null;
-  image?: string | null;
-  tagColors?: Record<string, string>;
-  primaryTagColor?: string;
-  className?: string;
-  effect?: MoireEffectPreset;
-}
-
-function ProjectCard({
-  title,
-  hook,
-  detail,
-  slug,
-  link,
-  keywords,
-  date,
-  image,
-  tagColors,
-  primaryTagColor,
-  className = "",
-  effect = DEFAULT_PROJECT_EFFECT,
-}: ProjectCardProps) {
-  const [isClicked, setIsClicked] = useState(false);
-
-  const handleClick = (e: React.MouseEvent) => {
-    if (!isClicked) {
-      e.preventDefault();
-      setIsClicked(true);
-    }
-  };
-
-  const _link = link ? (
-    <div className="projects__card__label projects__card__link">Link</div>
-  ) : null;
-
-  return (
-    <a
-      href={link || undefined}
-      target={link ? "_blank" : undefined}
-      rel={link ? "noreferrer" : undefined}
-      className={cn(
-        `projects__card ${className}`.trim(),
-        image && "has-image",
-        isClicked && "is-expanded",
-      )}
-      key={slug}
-      onClick={handleClick}
-    >
-      <PixelCanvas
-        className="projects__card__pixel-canvas"
-        colors={effect.colors}
-        gap={effect.gap}
-        speed={effect.speed}
-      />
-      <div className="projects__card__content">
-        <div className="projects__card__meta">
-          <p className="projects__card__year">{date ?? ""}</p>
-          <div className="projects__card__keywords">
-            {_link}
-            {keywords.map((keyword) => (
-              <div
-                key={keyword}
-                className="projects__card__label"
-                style={{
-                  backgroundColor:
-                    tagColors?.[keyword] ||
-                    primaryTagColor ||
-                    "rgba(255, 255, 255, 0.25)",
-                }}
-              >
-                {keyword}
-              </div>
-            ))}
-          </div>
-        </div>
-        <h3>{title}</h3>
-        <p className="projects__card__hook">{hook}</p>
-        <div
-          className={cn(
-            "projects__card__detail-wrapper",
-            isClicked && "show-text",
-          )}
-        >
-          <div className="projects__card__detail-inner">
-            <p className="projects__card__detail">{detail}</p>
-          </div>
-        </div>
-        {image && (
-          <img
-            src={image}
-            className="project-image"
-            alt="Project"
-            width={16}
-            height={9}
-          />
-        )}
-      </div>
-    </a>
-  );
-}
 interface ProjectsProps {
   db?: Pick<NotionData, "projects">;
 }
 
 function Projects({ db: propsDb }: ProjectsProps = {}) {
-  const [activeFilters, setActiveFilters] = useState<string[]>([]);
-  const [tagColors, setTagColors] = useState<Record<string, string>>({});
   const { db, isLoading } = useNotionSectionData(propsDb);
 
   const projectsData = useMemo(
     () => (Array.isArray(db?.projects) ? db.projects : []),
     [db?.projects],
   );
-  const allKeywords = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          projectsData.flatMap((project) =>
-            Array.isArray(project.keywords) ? project.keywords : [],
-          ),
-        ),
-      ).filter(
-        (keyword): keyword is string =>
-          typeof keyword === "string" && keyword.trim().length > 0,
-      ),
-    [projectsData],
-  );
-
-  const syncTagColors = useCallback(() => {
-    setTagColors(generateTagColors(allKeywords));
-  }, [allKeywords]);
-
-  const syncFilters = useCallback(() => {
-    setActiveFilters((prevFilters) =>
-      reconcileProjectFilters(prevFilters, allKeywords),
-    );
-  }, [allKeywords]);
-
-  useEffect(() => {
-    syncTagColors();
-    syncFilters();
-  }, [syncTagColors, syncFilters]);
-
-  useEffect(() => {
-    document.body.addEventListener("theme-changed", syncTagColors);
-
-    return () => {
-      document.body.removeEventListener("theme-changed", syncTagColors);
-    };
-  }, [syncTagColors]);
-
-  const toggleFilter = useCallback(
-    (filter: string) => {
-      setActiveFilters((prevFilters) => {
-        if (prevFilters.includes(filter)) {
-          if (prevFilters.length === 1) {
-            return [...allKeywords];
-          }
-          return prevFilters.filter((f) => f !== filter);
-        }
-
-        return [...prevFilters, filter];
-      });
-    },
-    [allKeywords],
-  );
-
-  const activeFiltersSet = useMemo(
-    () => new Set(activeFilters),
-    [activeFilters],
-  );
+  const { allKeywords, tagColors, activeFiltersSet, toggleFilter } =
+    useProjectFilters(projectsData);
 
   const project_cards = projectsData.map((projectProps, index) => {
     const primaryKeyword = projectProps.keywords[0] || "";

--- a/src/hooks/useProjectFilters.ts
+++ b/src/hooks/useProjectFilters.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ProjectItem } from "@/types/content";
+import { generateTagColors } from "@/utils/colorUtils";
+import { reconcileProjectFilters } from "@/utils/reconcileProjectFilters";
+
+export function useProjectFilters(projectsData: ProjectItem[]) {
+  const [activeFilters, setActiveFilters] = useState<string[]>([]);
+  const [tagColors, setTagColors] = useState<Record<string, string>>({});
+
+  const allKeywords = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          projectsData.flatMap((project) =>
+            Array.isArray(project.keywords) ? project.keywords : [],
+          ),
+        ),
+      ).filter(
+        (keyword): keyword is string =>
+          typeof keyword === "string" && keyword.trim().length > 0,
+      ),
+    [projectsData],
+  );
+
+  const syncTagColors = useCallback(() => {
+    setTagColors(generateTagColors(allKeywords));
+  }, [allKeywords]);
+
+  const syncFilters = useCallback(() => {
+    setActiveFilters((prevFilters) =>
+      reconcileProjectFilters(prevFilters, allKeywords),
+    );
+  }, [allKeywords]);
+
+  useEffect(() => {
+    syncTagColors();
+    syncFilters();
+  }, [syncTagColors, syncFilters]);
+
+  useEffect(() => {
+    document.body.addEventListener("theme-changed", syncTagColors);
+
+    return () => {
+      document.body.removeEventListener("theme-changed", syncTagColors);
+    };
+  }, [syncTagColors]);
+
+  const toggleFilter = useCallback(
+    (filter: string) => {
+      setActiveFilters((prevFilters) => {
+        if (prevFilters.includes(filter)) {
+          if (prevFilters.length === 1) {
+            return [...allKeywords];
+          }
+          return prevFilters.filter((f) => f !== filter);
+        }
+
+        return [...prevFilters, filter];
+      });
+    },
+    [allKeywords],
+  );
+
+  const activeFiltersSet = useMemo(
+    () => new Set(activeFilters),
+    [activeFilters],
+  );
+
+  return {
+    allKeywords,
+    tagColors,
+    activeFiltersSet,
+    toggleFilter,
+  };
+}


### PR DESCRIPTION
🎯 **What**
Extracted the complex project filtering logic (state for `activeFilters`, `tagColors`, `allKeywords`, and synchronization effects) from `src/components/content/Projects/Projects.tsx` into a new custom hook `useProjectFilters` located in `src/hooks/useProjectFilters.ts`.

💡 **Why**
The `Projects` function in `Projects.tsx` was flagged as an "Overly Long Function". Moving the filtering logic into a custom hook significantly reduces the size and complexity of the `Projects` component, improving its readability and maintainability. By separating state management from presentation, it is easier to test and reason about the component's behavior.

✅ **Verification**
1. Verified file modifications using `sed` to ensure the hook logic was properly extracted and removed from `Projects.tsx`.
2. Verified there are no format or linting errors using `npx @biomejs/biome check --write src/hooks/useProjectFilters.ts src/components/content/Projects/Projects.tsx`.
3. Ran the full test suite with coverage (`pnpm test -- --coverage`) to ensure no regressions were introduced. All tests passed.
4. Confirmed that no temporary files (`refactor2.py`) or artifacts (`coverage/`) were staged.

✨ **Result**
The `Projects` component is now much shorter and solely focused on presentation and data mapping. The filtering logic is neatly encapsulated in the reusable `useProjectFilters` hook, resolving the overly long function code health issue.

---
*PR created automatically by Jules for task [3189116541750582301](https://jules.google.com/task/3189116541750582301) started by @guitarbeat*

## Summary by Sourcery

Extract project filtering state into a reusable hook and split the Projects card UI into a dedicated component to simplify the Projects section.

Enhancements:
- Introduce a useProjectFilters hook to encapsulate project filtering state, keyword derivation, and tag color synchronization.
- Extract the ProjectCard JSX and behaviour from Projects.tsx into its own ProjectCard component to separate presentation from container logic.