### PR TITLE
🧹 Refactor useAvatarTransition hook to improve code health

### DIFF
--- a/src/components/content/Header/useAvatarTransition.tsx
+++ b/src/components/content/Header/useAvatarTransition.tsx
@@ -17,6 +17,131 @@ type AvatarPhase = "idle" | "shrink" | "slideOut" | "slideIn" | "expand";
 
 export { AVATAR_TRANSITION_FALLBACK_MS };
 
+function persistProfileIndex(index: number) {
+  try {
+    sessionStorage.setItem(PROFILE_INDEX_STORAGE_KEY, String(index));
+  } catch {
+    /* quota / private mode */
+  }
+}
+
+function handleImageError(e: React.SyntheticEvent<HTMLImageElement, Event>) {
+  const target = e.currentTarget;
+  target.onerror = null;
+  target.src = FALLBACK_PROFILE_SRC;
+
+  const picture = target.closest("picture");
+  const source = picture?.querySelector("source");
+  if (source) {
+    source.setAttribute("srcset", FALLBACK_PROFILE_WEBP_SRC);
+  }
+}
+
+function renderAvatarImage(
+  index: number,
+  className: string,
+  options: {
+    fetchPriority?: "high";
+    onTransitionEnd?: (e: React.TransitionEvent<HTMLImageElement>) => void;
+  } = {},
+) {
+  const image = PROFILE_IMAGES[index];
+
+  return (
+    <picture key={image.webpSrc}>
+      <source srcSet={image.webpSrc} type="image/webp" />
+      <img
+        className={cn("avatar__photo", className)}
+        src={image.src}
+        alt={image.alt}
+        width={image.width}
+        height={image.height}
+        fetchPriority={options.fetchPriority}
+        onError={handleImageError}
+        onTransitionEnd={options.onTransitionEnd}
+      />
+    </picture>
+  );
+}
+
+function getFrameClassName(phase: AvatarPhase, phaseAnimating: boolean) {
+  if (phase === "idle") {
+    return "avatar";
+  }
+
+  if (phase === "shrink") {
+    return cn(
+      "avatar",
+      "avatar--transitioning",
+      phaseAnimating ? "avatar--scale-rest" : "avatar--scale-from-hover",
+    );
+  }
+
+  if (phase === "slideOut" || phase === "slideIn") {
+    return cn("avatar", "avatar--transitioning", "avatar--scale-rest");
+  }
+
+  if (phase === "expand") {
+    return cn(
+      "avatar",
+      "avatar--transitioning",
+      phaseAnimating ? "avatar--scale-hover" : "avatar--scale-rest",
+    );
+  }
+
+  return "avatar";
+}
+
+function renderContent(
+  phase: AvatarPhase,
+  phaseAnimating: boolean,
+  profileIndex: number,
+  outgoingIndex: number | null,
+  incomingIndex: number | null,
+  handlePhotoTransitionEnd: (
+    e: React.TransitionEvent<HTMLImageElement>,
+  ) => void,
+) {
+  if (phase === "idle") {
+    return renderAvatarImage(profileIndex, "avatar__photo--active", {
+      fetchPriority: "high",
+    });
+  }
+
+  if ((phase === "shrink" || phase === "slideOut") && outgoingIndex !== null) {
+    return renderAvatarImage(
+      outgoingIndex,
+      cn(
+        "avatar__photo--outgoing",
+        phase === "slideOut" &&
+          phaseAnimating &&
+          "avatar__photo--outgoing-exiting",
+      ),
+      {
+        onTransitionEnd:
+          phase === "slideOut" ? handlePhotoTransitionEnd : undefined,
+      },
+    );
+  }
+
+  if ((phase === "slideIn" || phase === "expand") && incomingIndex !== null) {
+    const photoClassName =
+      phase === "expand"
+        ? "avatar__photo--active"
+        : cn(
+            "avatar__photo--incoming",
+            phaseAnimating && "avatar__photo--incoming-active",
+          );
+
+    return renderAvatarImage(incomingIndex, photoClassName, {
+      onTransitionEnd:
+        phase === "slideIn" ? handlePhotoTransitionEnd : undefined,
+    });
+  }
+
+  return null;
+}
+
 export function useAvatarTransition() {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const transitionFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -37,14 +162,6 @@ export function useAvatarTransition() {
   phaseRef.current = phase;
   incomingIndexRef.current = incomingIndex;
 
-  const persistProfileIndex = useCallback((index: number) => {
-    try {
-      sessionStorage.setItem(PROFILE_INDEX_STORAGE_KEY, String(index));
-    } catch {
-      /* quota / private mode */
-    }
-  }, []);
-
   const completeTransition = useCallback(() => {
     if (transitionFallbackRef.current) {
       clearTimeout(transitionFallbackRef.current);
@@ -63,7 +180,7 @@ export function useAvatarTransition() {
     setIncomingIndex(null);
     shouldExpandRef.current = false;
     setPhaseAnimating(false);
-  }, [persistProfileIndex]);
+  }, []);
 
   useEffect(() => {
     if (phase === "idle") {
@@ -108,7 +225,7 @@ export function useAvatarTransition() {
     transitionFallbackRef.current = setTimeout(() => {
       completeTransition();
     }, AVATAR_TRANSITION_FALLBACK_MS);
-  }, [completeTransition, persistProfileIndex, profileIndex]);
+  }, [completeTransition, profileIndex]);
 
   const handleFrameTransitionEnd = useCallback(
     (e: React.TransitionEvent<HTMLSpanElement>) => {
@@ -159,122 +276,16 @@ export function useAvatarTransition() {
     [completeTransition],
   );
 
-  const handleImageError = useCallback(
-    (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
-      const target = e.currentTarget;
-      target.onerror = null;
-      target.src = FALLBACK_PROFILE_SRC;
+  const frameClassName = getFrameClassName(phase, phaseAnimating);
 
-      const picture = target.closest("picture");
-      const source = picture?.querySelector("source");
-      if (source) {
-        source.setAttribute("srcset", FALLBACK_PROFILE_WEBP_SRC);
-      }
-    },
-    [],
+  const content = renderContent(
+    phase,
+    phaseAnimating,
+    profileIndex,
+    outgoingIndex,
+    incomingIndex,
+    handlePhotoTransitionEnd,
   );
-
-  const renderAvatarImage = useCallback(
-    (
-      index: number,
-      className: string,
-      options: {
-        fetchPriority?: "high";
-        onTransitionEnd?: (e: React.TransitionEvent<HTMLImageElement>) => void;
-      } = {},
-    ) => {
-      const image = PROFILE_IMAGES[index];
-
-      return (
-        <picture key={image.webpSrc}>
-          <source srcSet={image.webpSrc} type="image/webp" />
-          <img
-            className={cn("avatar__photo", className)}
-            src={image.src}
-            alt={image.alt}
-            width={image.width}
-            height={image.height}
-            fetchPriority={options.fetchPriority}
-            onError={handleImageError}
-            onTransitionEnd={options.onTransitionEnd}
-          />
-        </picture>
-      );
-    },
-    [handleImageError],
-  );
-
-  const frameClassName = (() => {
-    if (phase === "idle") {
-      return "avatar";
-    }
-
-    if (phase === "shrink") {
-      return cn(
-        "avatar",
-        "avatar--transitioning",
-        phaseAnimating ? "avatar--scale-rest" : "avatar--scale-from-hover",
-      );
-    }
-
-    if (phase === "slideOut" || phase === "slideIn") {
-      return cn("avatar", "avatar--transitioning", "avatar--scale-rest");
-    }
-
-    if (phase === "expand") {
-      return cn(
-        "avatar",
-        "avatar--transitioning",
-        phaseAnimating ? "avatar--scale-hover" : "avatar--scale-rest",
-      );
-    }
-
-    return "avatar";
-  })();
-
-  const content = (() => {
-    if (phase === "idle") {
-      return renderAvatarImage(profileIndex, "avatar__photo--active", {
-        fetchPriority: "high",
-      });
-    }
-
-    if (
-      (phase === "shrink" || phase === "slideOut") &&
-      outgoingIndex !== null
-    ) {
-      return renderAvatarImage(
-        outgoingIndex,
-        cn(
-          "avatar__photo--outgoing",
-          phase === "slideOut" &&
-            phaseAnimating &&
-            "avatar__photo--outgoing-exiting",
-        ),
-        {
-          onTransitionEnd:
-            phase === "slideOut" ? handlePhotoTransitionEnd : undefined,
-        },
-      );
-    }
-
-    if ((phase === "slideIn" || phase === "expand") && incomingIndex !== null) {
-      const photoClassName =
-        phase === "expand"
-          ? "avatar__photo--active"
-          : cn(
-              "avatar__photo--incoming",
-              phaseAnimating && "avatar__photo--incoming-active",
-            );
-
-      return renderAvatarImage(incomingIndex, photoClassName, {
-        onTransitionEnd:
-          phase === "slideIn" ? handlePhotoTransitionEnd : undefined,
-      });
-    }
-
-    return null;
-  })();
 
   return {
     buttonRef,


### PR DESCRIPTION
🎯 **What:** Extracted pure helper functions out of the overly long `useAvatarTransition` React hook to improve readability.
💡 **Why:** Smaller functions are easier to test, read, and maintain. Also avoids unnecessary memoization on each render.
✅ **Verification:** Ran test suite, verified with `sed`, ensured no functional changes by requesting code review.
✨ **Result:** A much leaner, highly-readable component hook.

---
*PR created automatically by Jules for task [15909292709338453717](https://jules.google.com/task/15909292709338453717) started by @guitarbeat*

## Summary by Sourcery

Refactor the useAvatarTransition hook by extracting pure helper functions for avatar persistence, rendering, and styling to simplify the hook logic and improve readability.

Enhancements:
- Extract pure utility functions for persisting profile index, handling avatar image errors, computing frame class names, and rendering avatar content outside the hook.
- Simplify useAvatarTransition by removing unnecessary memoization and inline logic without changing observable behavior.