### PR TITLE
🧪 [testing improvement] Add tests for useNotionSectionData hook

### DIFF
--- a/src/hooks/__tests__/useNotionSectionData.test.ts
+++ b/src/hooks/__tests__/useNotionSectionData.test.ts
@@ -1,0 +1,72 @@
+import { renderHook } from '@testing-library/react';
+import { useNotionSectionData } from '../useNotionSectionData';
+import { useNotion } from '../../contexts/NotionContext';
+import type { NotionData } from '../../types/content';
+
+// Mock the NotionContext
+jest.mock('../../contexts/NotionContext', () => ({
+  useNotion: jest.fn(),
+}));
+
+describe('useNotionSectionData', () => {
+  const mockContextDb = {
+    work: [],
+    projects: [],
+  } as unknown as Partial<NotionData>;
+
+  const mockPropsDb = {
+    work: [{ id: '1', properties: {} }],
+  } as unknown as Partial<NotionData>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use context data when propsDb is undefined', () => {
+    (useNotion as jest.Mock).mockReturnValue({
+      db: mockContextDb,
+      loading: true,
+    });
+
+    const { result } = renderHook(() => useNotionSectionData());
+
+    expect(result.current.db).toBe(mockContextDb);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should use context data and not be loading when context loading is false', () => {
+    (useNotion as jest.Mock).mockReturnValue({
+      db: mockContextDb,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useNotionSectionData());
+
+    expect(result.current.db).toBe(mockContextDb);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should use propsDb when provided and set isLoading to false even if context is loading', () => {
+    (useNotion as jest.Mock).mockReturnValue({
+      db: mockContextDb,
+      loading: true,
+    });
+
+    const { result } = renderHook(() => useNotionSectionData(mockPropsDb));
+
+    expect(result.current.db).toBe(mockPropsDb);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should use propsDb when provided and context is not loading', () => {
+    (useNotion as jest.Mock).mockReturnValue({
+      db: mockContextDb,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useNotionSectionData(mockPropsDb));
+
+    expect(result.current.db).toBe(mockPropsDb);
+    expect(result.current.isLoading).toBe(false);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `useNotionSectionData` hook to verify its logic in handling context and prop-based `NotionData`.

📊 **Coverage:** 
- Tested when `propsDb` is undefined, verifying it correctly falls back to `contextDb` and sets `isLoading` based on context's loading state.
- Tested when context data is not loading.
- Tested when `propsDb` is provided, confirming it overrides `contextDb` and forces `isLoading` to false regardless of the context's loading state.

✨ **Result:** Improved test coverage and reliability for `useNotionSectionData`, ensuring it correctly manages and prioritizes Notion data sources.

---
*PR created automatically by Jules for task [4565230036921965688](https://jules.google.com/task/4565230036921965688) started by @guitarbeat*

## Summary by Sourcery

Add unit test coverage for the useNotionSectionData hook to validate its behavior with context and prop-supplied Notion data.

Tests:
- Add tests confirming useNotionSectionData falls back to context data when no propsDb is provided and reflects the context loading state.
- Add tests verifying propsDb, when provided, overrides context data and always results in a non-loading state.