### PR TITLE
🔒 Add noopener to target='_blank' links

### DIFF
--- a/src/components/content/Projects/Projects.tsx
+++ b/src/components/content/Projects/Projects.tsx
@@ -58,7 +58,7 @@ function ProjectCard({
     <a
       href={link || undefined}
       target={link ? "_blank" : undefined}
-      rel={link ? "noreferrer" : undefined}
+      rel={link ? "noopener noreferrer" : undefined}
       className={cn(
         `projects__card ${className}`.trim(),
         image && "has-image",


### PR DESCRIPTION
🎯 **What:** Added `noopener` to the `rel` attribute in the `<a target="_blank">` tag in `src/components/content/Projects/Projects.tsx`.

⚠️ **Risk:** Links opening in a new tab using `target="_blank"` without `noopener` expose the `window.opener` API to the destination page. A malicious destination page can abuse this to navigate the original page to a phishing site (reverse tabnabbing).

🛡️ **Solution:** Added `noopener` to ensure the newly opened page runs in a separate process and cannot access the `window.opener` object, closing this attack vector. Existing functionality (like `noreferrer`) was preserved.

---
*PR created automatically by Jules for task [14430946642286097339](https://jules.google.com/task/14430946642286097339) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Prevent reverse tabnabbing by adding `noopener` to `rel` on project links that use `target="_blank"`.