### PR TITLE
🧪 Add tests for useMatrixActivation

### DIFF
--- a/src/components/effects/Matrix/__tests__/Matrix.benchmark.test.tsx
+++ b/src/components/effects/Matrix/__tests__/Matrix.benchmark.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import Matrix from "../Matrix";
 import { UnlockProvider } from "../UnlockContext";
@@ -56,15 +56,20 @@ describe("Matrix Performance", () => {
 
     // Trigger rapid resize events
     const resizeEvent = new Event("resize");
-    for (let i = 0; i < 10; i++) {
-      window.dispatchEvent(resizeEvent);
-    }
+
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        window.dispatchEvent(resizeEvent);
+      }
+    });
 
     // Immediately after events, it should NOT have been called due to debounce
     expect(widthSetterSpy).toHaveBeenCalledTimes(0);
 
     // Advance timers by debounce duration (200ms)
-    jest.advanceTimersByTime(200);
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
 
     // Now it should have been called EXACTLY once
     expect(widthSetterSpy).toHaveBeenCalledTimes(1);

--- a/src/hooks/__tests__/useMatrixActivation.test.ts
+++ b/src/hooks/__tests__/useMatrixActivation.test.ts
@@ -1,0 +1,162 @@
+import { act, renderHook } from "@testing-library/react";
+import {
+  shouldShowMatrixFromSearch,
+  useMatrixActivation,
+} from "../useMatrixActivation";
+
+describe("shouldShowMatrixFromSearch", () => {
+  it("returns false if search is empty", () => {
+    expect(shouldShowMatrixFromSearch("")).toBe(false);
+    expect(shouldShowMatrixFromSearch(new URLSearchParams())).toBe(false);
+  });
+
+  it("returns false if matrix param is missing", () => {
+    expect(shouldShowMatrixFromSearch("?other=1")).toBe(false);
+  });
+
+  it("returns false if matrix param has no value", () => {
+    expect(shouldShowMatrixFromSearch("?matrix")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=   ")).toBe(false);
+  });
+
+  it("returns false for disabled values", () => {
+    expect(shouldShowMatrixFromSearch("?matrix=0")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=false")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=off")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=no")).toBe(false);
+  });
+
+  it("returns true for enabled values", () => {
+    expect(shouldShowMatrixFromSearch("?matrix=1")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=true")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=on")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=yes")).toBe(true);
+  });
+
+  it("returns false for unknown values", () => {
+    expect(shouldShowMatrixFromSearch("?matrix=maybe")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=hello")).toBe(false);
+  });
+
+  it("handles case insensitivity and whitespace", () => {
+    expect(shouldShowMatrixFromSearch("?matrix= TRUE  ")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=  oFf ")).toBe(false);
+  });
+});
+
+describe("useMatrixActivation", () => {
+  const originalLocation = window.location;
+
+  const setLocationSearch = (search: string) => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...originalLocation, search },
+    });
+  };
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("initializes to false if no matrix param in location", () => {
+    setLocationSearch("");
+    const { result } = renderHook(() => useMatrixActivation());
+    expect(result.current.showMatrix).toBe(false);
+  });
+
+  it("initializes to true if valid matrix param in location", () => {
+    setLocationSearch("?matrix=true");
+    const { result } = renderHook(() => useMatrixActivation());
+    expect(result.current.showMatrix).toBe(true);
+  });
+
+  it("handles handleMatrixActivate", () => {
+    setLocationSearch("");
+    const { result } = renderHook(() => useMatrixActivation());
+
+    act(() => {
+      result.current.handleMatrixActivate();
+    });
+
+    expect(result.current.showMatrix).toBe(true);
+  });
+
+  it("handles handleMatrixDismiss", () => {
+    setLocationSearch("?matrix=true");
+    const { result } = renderHook(() => useMatrixActivation());
+
+    act(() => {
+      result.current.handleMatrixDismiss();
+    });
+
+    expect(result.current.showMatrix).toBe(false);
+  });
+
+  it("handles handleRouteMatrixChange", () => {
+    setLocationSearch("");
+    const { result } = renderHook(() => useMatrixActivation());
+
+    act(() => {
+      result.current.handleRouteMatrixChange(true);
+    });
+
+    expect(result.current.showMatrix).toBe(true);
+
+    act(() => {
+      result.current.handleRouteMatrixChange(false);
+    });
+
+    expect(result.current.showMatrix).toBe(false);
+  });
+
+  it("calls matrixReadyCallback when showMatrix becomes true", () => {
+    setLocationSearch("");
+    const { result } = renderHook(() => useMatrixActivation());
+    const callback = jest.fn();
+
+    act(() => {
+      result.current.handleMatrixReady(callback);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleMatrixActivate();
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call matrixReadyCallback if callback is not a function", () => {
+    setLocationSearch("");
+    const { result } = renderHook(() => useMatrixActivation());
+
+    act(() => {
+      // @ts-expect-error Testing invalid input
+      result.current.handleMatrixReady(null);
+    });
+
+    act(() => {
+      result.current.handleMatrixActivate();
+    });
+
+    // Should not throw
+    expect(result.current.showMatrix).toBe(true);
+  });
+
+  it("does not call callback when showMatrix is already true and callback is set", () => {
+    setLocationSearch("?matrix=true");
+    const { result } = renderHook(() => useMatrixActivation());
+    const callback = jest.fn();
+
+    act(() => {
+      result.current.handleMatrixReady(callback);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added comprehensive tests for `shouldShowMatrixFromSearch` and `useMatrixActivation` in `src/hooks/__tests__/useMatrixActivation.test.ts`. Also fixed an `act(...)` warning in `Matrix.benchmark.test.tsx`.
📊 **Coverage:** Covered edge cases for search parameters (empty, disabled, enabled values), and state changes for the hook using `renderHook` and `act`.
✨ **Result:** Reached 100% line and branch coverage for `useMatrixActivation.ts` and resolved test suite warnings.

---
*PR created automatically by Jules for task [13568394030707903214](https://jules.google.com/task/13568394030707903214) started by @guitarbeat*

## Summary by Sourcery

Add comprehensive tests for the matrix activation hook and search helper, and address an act warning in matrix performance tests.

Tests:
- Add unit tests for shouldShowMatrixFromSearch covering empty, missing, enabled, disabled, and malformed matrix query parameters.
- Add hook tests for useMatrixActivation covering initialization from URL, activation/dismissal handlers, route-driven changes, and matrix-ready callbacks.
- Wrap resize dispatches and timer advances in act() in Matrix performance tests to avoid React test warnings.