### PR TITLE
🧹 Extract helper functions from useAvatarTransition hook

### DIFF
--- a/src/components/content/Header/Header.test.tsx
+++ b/src/components/content/Header/Header.test.tsx
@@ -27,7 +27,9 @@ describe("Header avatar", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-    jest.runOnlyPendingTimers();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
     jest.useRealTimers();
   });
 

--- a/src/components/content/Header/useAvatarTransition.tsx
+++ b/src/components/content/Header/useAvatarTransition.tsx
@@ -17,6 +17,134 @@ type AvatarPhase = "idle" | "shrink" | "slideOut" | "slideIn" | "expand";
 
 export { AVATAR_TRANSITION_FALLBACK_MS };
 
+const persistProfileIndex = (index: number) => {
+  try {
+    sessionStorage.setItem(PROFILE_INDEX_STORAGE_KEY, String(index));
+  } catch {
+    /* quota / private mode */
+  }
+};
+
+const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+  const target = e.currentTarget;
+  target.onerror = null;
+  target.src = FALLBACK_PROFILE_SRC;
+
+  const picture = target.closest("picture");
+  const source = picture?.querySelector("source");
+  if (source) {
+    source.setAttribute("srcset", FALLBACK_PROFILE_WEBP_SRC);
+  }
+};
+
+const renderAvatarImage = (
+  index: number,
+  className: string,
+  options: {
+    fetchPriority?: "high";
+    onTransitionEnd?: (e: React.TransitionEvent<HTMLImageElement>) => void;
+  } = {},
+) => {
+  const image = PROFILE_IMAGES[index];
+
+  return (
+    <picture key={image.webpSrc}>
+      <source srcSet={image.webpSrc} type="image/webp" />
+      <img
+        className={cn("avatar__photo", className)}
+        src={image.src}
+        alt={image.alt}
+        width={image.width}
+        height={image.height}
+        fetchPriority={options.fetchPriority}
+        onError={handleImageError}
+        onTransitionEnd={options.onTransitionEnd}
+      />
+    </picture>
+  );
+};
+
+const getFrameClassName = (
+  phase: AvatarPhase,
+  phaseAnimating: boolean,
+): string => {
+  if (phase === "idle") {
+    return "avatar";
+  }
+
+  if (phase === "shrink") {
+    return cn(
+      "avatar",
+      "avatar--transitioning",
+      phaseAnimating ? "avatar--scale-rest" : "avatar--scale-from-hover",
+    );
+  }
+
+  if (phase === "slideOut" || phase === "slideIn") {
+    return cn("avatar", "avatar--transitioning", "avatar--scale-rest");
+  }
+
+  if (phase === "expand") {
+    return cn(
+      "avatar",
+      "avatar--transitioning",
+      phaseAnimating ? "avatar--scale-hover" : "avatar--scale-rest",
+    );
+  }
+
+  return "avatar";
+};
+
+const renderContent = (
+  phase: AvatarPhase,
+  phaseAnimating: boolean,
+  profileIndex: number,
+  outgoingIndex: number | null,
+  incomingIndex: number | null,
+  handlePhotoTransitionEnd: (
+    e: React.TransitionEvent<HTMLImageElement>,
+  ) => void,
+) => {
+  if (phase === "idle") {
+    return renderAvatarImage(profileIndex, "avatar__photo--active", {
+      fetchPriority: "high",
+    });
+  }
+
+  if ((phase === "shrink" || phase === "slideOut") && outgoingIndex !== null) {
+    return renderAvatarImage(
+      outgoingIndex,
+      cn(
+        "avatar__photo--outgoing",
+        phase === "slideOut" &&
+          phaseAnimating &&
+          "avatar__photo--outgoing-exiting",
+      ),
+      {
+        onTransitionEnd:
+          phase === "slideOut" ? handlePhotoTransitionEnd : undefined,
+      },
+    );
+  }
+
+  if ((phase === "slideIn" || phase === "expand") && incomingIndex !== null) {
+    const photoClassName =
+      phase === "expand"
+        ? "avatar__photo--active"
+        : cn(
+            "avatar__photo--incoming",
+            phaseAnimating && "avatar__photo--incoming-active",
+          );
+
+    return renderAvatarImage(incomingIndex, photoClassName, {
+      onTransitionEnd:
+        phase === "slideIn" ? handlePhotoTransitionEnd : undefined,
+    });
+  }
+
+  return null;
+};
+
 export function useAvatarTransition() {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const transitionFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -37,14 +165,6 @@ export function useAvatarTransition() {
   phaseRef.current = phase;
   incomingIndexRef.current = incomingIndex;
 
-  const persistProfileIndex = useCallback((index: number) => {
-    try {
-      sessionStorage.setItem(PROFILE_INDEX_STORAGE_KEY, String(index));
-    } catch {
-      /* quota / private mode */
-    }
-  }, []);
-
   const completeTransition = useCallback(() => {
     if (transitionFallbackRef.current) {
       clearTimeout(transitionFallbackRef.current);
@@ -63,7 +183,7 @@ export function useAvatarTransition() {
     setIncomingIndex(null);
     shouldExpandRef.current = false;
     setPhaseAnimating(false);
-  }, [persistProfileIndex]);
+  }, []);
 
   useEffect(() => {
     if (phase === "idle") {
@@ -108,7 +228,7 @@ export function useAvatarTransition() {
     transitionFallbackRef.current = setTimeout(() => {
       completeTransition();
     }, AVATAR_TRANSITION_FALLBACK_MS);
-  }, [completeTransition, persistProfileIndex, profileIndex]);
+  }, [completeTransition, profileIndex]);
 
   const handleFrameTransitionEnd = useCallback(
     (e: React.TransitionEvent<HTMLSpanElement>) => {
@@ -159,122 +279,16 @@ export function useAvatarTransition() {
     [completeTransition],
   );
 
-  const handleImageError = useCallback(
-    (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
-      const target = e.currentTarget;
-      target.onerror = null;
-      target.src = FALLBACK_PROFILE_SRC;
+  const frameClassName = getFrameClassName(phase, phaseAnimating);
 
-      const picture = target.closest("picture");
-      const source = picture?.querySelector("source");
-      if (source) {
-        source.setAttribute("srcset", FALLBACK_PROFILE_WEBP_SRC);
-      }
-    },
-    [],
+  const content = renderContent(
+    phase,
+    phaseAnimating,
+    profileIndex,
+    outgoingIndex,
+    incomingIndex,
+    handlePhotoTransitionEnd,
   );
-
-  const renderAvatarImage = useCallback(
-    (
-      index: number,
-      className: string,
-      options: {
-        fetchPriority?: "high";
-        onTransitionEnd?: (e: React.TransitionEvent<HTMLImageElement>) => void;
-      } = {},
-    ) => {
-      const image = PROFILE_IMAGES[index];
-
-      return (
-        <picture key={image.webpSrc}>
-          <source srcSet={image.webpSrc} type="image/webp" />
-          <img
-            className={cn("avatar__photo", className)}
-            src={image.src}
-            alt={image.alt}
-            width={image.width}
-            height={image.height}
-            fetchPriority={options.fetchPriority}
-            onError={handleImageError}
-            onTransitionEnd={options.onTransitionEnd}
-          />
-        </picture>
-      );
-    },
-    [handleImageError],
-  );
-
-  const frameClassName = (() => {
-    if (phase === "idle") {
-      return "avatar";
-    }
-
-    if (phase === "shrink") {
-      return cn(
-        "avatar",
-        "avatar--transitioning",
-        phaseAnimating ? "avatar--scale-rest" : "avatar--scale-from-hover",
-      );
-    }
-
-    if (phase === "slideOut" || phase === "slideIn") {
-      return cn("avatar", "avatar--transitioning", "avatar--scale-rest");
-    }
-
-    if (phase === "expand") {
-      return cn(
-        "avatar",
-        "avatar--transitioning",
-        phaseAnimating ? "avatar--scale-hover" : "avatar--scale-rest",
-      );
-    }
-
-    return "avatar";
-  })();
-
-  const content = (() => {
-    if (phase === "idle") {
-      return renderAvatarImage(profileIndex, "avatar__photo--active", {
-        fetchPriority: "high",
-      });
-    }
-
-    if (
-      (phase === "shrink" || phase === "slideOut") &&
-      outgoingIndex !== null
-    ) {
-      return renderAvatarImage(
-        outgoingIndex,
-        cn(
-          "avatar__photo--outgoing",
-          phase === "slideOut" &&
-            phaseAnimating &&
-            "avatar__photo--outgoing-exiting",
-        ),
-        {
-          onTransitionEnd:
-            phase === "slideOut" ? handlePhotoTransitionEnd : undefined,
-        },
-      );
-    }
-
-    if ((phase === "slideIn" || phase === "expand") && incomingIndex !== null) {
-      const photoClassName =
-        phase === "expand"
-          ? "avatar__photo--active"
-          : cn(
-              "avatar__photo--incoming",
-              phaseAnimating && "avatar__photo--incoming-active",
-            );
-
-      return renderAvatarImage(incomingIndex, photoClassName, {
-        onTransitionEnd:
-          phase === "slideIn" ? handlePhotoTransitionEnd : undefined,
-      });
-    }
-
-    return null;
-  })();
 
   return {
     buttonRef,


### PR DESCRIPTION
🎯 **What:** Extracted internal helper functions (`persistProfileIndex`, `handleImageError`, `renderAvatarImage`, `getFrameClassName`, and `renderContent`) out of the `useAvatarTransition` hook. Also wrapped `jest.runOnlyPendingTimers()` with `act()` in `Header.test.tsx`.
💡 **Why:** The `useAvatarTransition` function was overly long and complex. Extracting these functions separates concerns, drastically reduces the size of the hook, and improves readability and maintainability. Wrapping the test timer with `act()` removes React testing warnings.
✅ **Verification:** Verified by successfully running `pnpm test src/components/content/Header/Header.test.tsx` and running the entire test suite via `pnpm test -- --watchAll=false` to ensure no regressions occurred. Also ran format and lint tools.
✨ **Result:** The `useAvatarTransition` hook is now much more focused on state management, making the code much easier to read and maintain, while all existing functionality works as intended.

---
*PR created automatically by Jules for task [17849468550210762239](https://jules.google.com/task/17849468550210762239) started by @guitarbeat*

## Summary by Sourcery

Refactor the avatar transition logic in the Header to use extracted helper functions and adjust tests to comply with React testing act() timing requirements.

Bug Fixes:
- Wrap pending timer flushing in Header avatar tests with React testing act() to eliminate timing-related warnings.

Enhancements:
- Extract avatar transition helper logic (storage persistence, image error handling, frame class name calculation, and content rendering) out of the useAvatarTransition hook to simplify and focus it on state management.

Tests:
- Update Header avatar tests to run pending timers inside act() while maintaining existing timer cleanup behavior.