### PR TITLE
🧪 [Testing Improvement] Add Error Path Tests for NotionService

### DIFF
--- a/src/components/content/Header/Header.test.tsx
+++ b/src/components/content/Header/Header.test.tsx
@@ -27,7 +27,7 @@ describe("Header avatar", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-    jest.runOnlyPendingTimers();
+    act(() => { jest.runOnlyPendingTimers(); });
     jest.useRealTimers();
   });
 

--- a/src/components/effects/Matrix/__tests__/Matrix.benchmark.test.tsx
+++ b/src/components/effects/Matrix/__tests__/Matrix.benchmark.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import Matrix from "../Matrix";
 import { UnlockProvider } from "../UnlockContext";
@@ -56,15 +56,19 @@ describe("Matrix Performance", () => {
 
     // Trigger rapid resize events
     const resizeEvent = new Event("resize");
-    for (let i = 0; i < 10; i++) {
-      window.dispatchEvent(resizeEvent);
-    }
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        window.dispatchEvent(resizeEvent);
+      }
+    });
 
     // Immediately after events, it should NOT have been called due to debounce
     expect(widthSetterSpy).toHaveBeenCalledTimes(0);
 
     // Advance timers by debounce duration (200ms)
-    jest.advanceTimersByTime(200);
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
 
     // Now it should have been called EXACTLY once
     expect(widthSetterSpy).toHaveBeenCalledTimes(1);

--- a/src/services/notionService.test.ts
+++ b/src/services/notionService.test.ts
@@ -1,0 +1,70 @@
+import NotionService from "./notionService";
+
+describe("NotionService", () => {
+  let service: NotionService;
+
+  beforeEach(() => {
+    service = new NotionService();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("getAllData", () => {
+    it("fetches content successfully", async () => {
+      const mockData = {
+        data: [],
+        meta: {}
+      };
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockData),
+      });
+
+      const result = await service.getAllData();
+      expect(result).toEqual(mockData);
+    });
+
+    it("throws a parsed error when response is not ok and JSON has an error message", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        statusText: "Bad Request",
+        json: jest.fn().mockResolvedValue({ message: "Custom API Error" }),
+      });
+
+      await expect(service.getAllData()).rejects.toThrow("Custom API Error");
+    });
+
+    it("throws a parsed error when response is not ok and JSON has a nested error message", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        statusText: "Bad Request",
+        json: jest.fn().mockResolvedValue({ error: { message: "Nested Error Message" } }),
+      });
+
+      await expect(service.getAllData()).rejects.toThrow("Nested Error Message");
+    });
+
+    it("throws a fallback error when .json() throws and response is not ok", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        statusText: "Internal Server Error",
+        json: jest.fn().mockRejectedValue(new Error("Invalid JSON")),
+      });
+
+      await expect(service.getAllData()).rejects.toThrow("Internal Server Error");
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("/api/content"), { method: "GET" });
+    });
+
+    it("throws an error when response is ok but payload is invalid", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({}),
+      });
+
+      await expect(service.getAllData()).rejects.toThrow(/Content API returned an invalid response/);
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** 
Added the missing tests for `NotionService` (`src/services/notionService.ts`), filling a gap in testing error handling behavior when the `fetch` API response is not ok and its `.json()` method fails (throws an exception). I also took the liberty of adding a few wrappers to unrelated tests to get rid of React `act` warnings.

📊 **Coverage:** 
- The happy path for `getAllData` successfully fetching content.
- Error path when the JSON payload contains a top-level `message`.
- Error path when the JSON payload contains a nested `error.message`.
- Error path when `.json()` rejects while the response is not OK (fallback error to `statusText`).
- Error path when the response is OK but the payload lacks expected properties.

✨ **Result:** 
`NotionService` is now fully tested with deterministic tests that accurately mimic external API failure scenarios, increasing reliability and closing the identified testing gap. Overall test suite reliability improved slightly by fixing unrelated `act` warnings.

---
*PR created automatically by Jules for task [2917546476602039455](https://jules.google.com/task/2917546476602039455) started by @guitarbeat*

## Summary by Sourcery

Add comprehensive error-path coverage for NotionService and address React testing act timing issues in existing tests.

Tests:
- Add unit tests for NotionService#getAllData covering successful fetch, multiple error response shapes, JSON parsing failures, and invalid payloads.
- Wrap resize-event and timer-based expectations in existing Matrix and Header tests with React Testing Library act to eliminate act-related warnings.