### PR TITLE
🧪 [Add unit tests for shouldShowMatrixFromSearch]

### DIFF
--- a/src/hooks/__tests__/useMatrixActivation.test.ts
+++ b/src/hooks/__tests__/useMatrixActivation.test.ts
@@ -1,0 +1,66 @@
+import { shouldShowMatrixFromSearch } from "../useMatrixActivation";
+
+describe("shouldShowMatrixFromSearch", () => {
+  it("returns false when no matrix parameter is present", () => {
+    expect(shouldShowMatrixFromSearch("")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?other=1")).toBe(false);
+  });
+
+  it("returns false when matrix parameter has no value", () => {
+    expect(shouldShowMatrixFromSearch("?matrix=")).toBe(false);
+  });
+
+  it("returns true for enabled values", () => {
+    expect(shouldShowMatrixFromSearch("?matrix=1")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=true")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=on")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=yes")).toBe(true);
+  });
+
+  it("returns false for disabled values", () => {
+    expect(shouldShowMatrixFromSearch("?matrix=0")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=false")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=off")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=no")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(shouldShowMatrixFromSearch("?matrix=TRUE")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=Yes")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=OFF")).toBe(false);
+  });
+
+  it("trims whitespace from values", () => {
+    expect(shouldShowMatrixFromSearch("?matrix= true ")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix=  1  ")).toBe(true);
+    expect(shouldShowMatrixFromSearch("?matrix= off ")).toBe(false);
+  });
+
+  it("returns false for unrecognized values", () => {
+    expect(shouldShowMatrixFromSearch("?matrix=2")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=blah")).toBe(false);
+    expect(shouldShowMatrixFromSearch("?matrix=maybe")).toBe(false);
+  });
+
+  it("handles URLSearchParams objects", () => {
+    const params = new URLSearchParams("?matrix=yes");
+    expect(shouldShowMatrixFromSearch(params)).toBe(true);
+
+    const params2 = new URLSearchParams("?matrix=false");
+    expect(shouldShowMatrixFromSearch(params2)).toBe(false);
+
+    const emptyParams = new URLSearchParams();
+    expect(shouldShowMatrixFromSearch(emptyParams)).toBe(false);
+  });
+
+  it("handles invalid input gracefully", () => {
+    // @ts-expect-error Testing invalid input type
+    expect(shouldShowMatrixFromSearch(null)).toBe(false);
+    // @ts-expect-error Testing invalid input type
+    expect(shouldShowMatrixFromSearch(undefined)).toBe(false);
+    // @ts-expect-error Testing invalid input type
+    expect(shouldShowMatrixFromSearch(123)).toBe(false);
+    // @ts-expect-error Testing invalid input type
+    expect(shouldShowMatrixFromSearch({})).toBe(false);
+  });
+});


### PR DESCRIPTION
🎯 **What:** 
The `shouldShowMatrixFromSearch` function in `src/hooks/useMatrixActivation.ts` determines if the Matrix easter egg should be shown based on search parameters, but it was entirely untested. This PR introduces comprehensive unit tests for this function.

📊 **Coverage:**
The new tests in `src/hooks/__tests__/useMatrixActivation.test.ts` cover:
- Happy paths for enabled values (`1`, `true`, `on`, `yes`).
- Happy paths for disabled values (`0`, `false`, `off`, `no`).
- Missing or empty parameters.
- Case-insensitivity (`TRUE`, `Yes`, `OFF`).
- Whitespace trimming.
- Unrecognized values.
- `URLSearchParams` object inputs.
- Graceful failure for invalid input types (using `@ts-expect-error`).

✨ **Result:**
The hook is now fully tested, ensuring that the easter egg activation logic remains reliable and safe against regressions during future refactoring.

---
*PR created automatically by Jules for task [1349937558721988762](https://jules.google.com/task/1349937558721988762) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Introduce comprehensive unit tests for shouldShowMatrixFromSearch covering enabled/disabled values, case-insensitivity, whitespace, missing/invalid parameters, and URLSearchParams inputs.