### PR TITLE
🧹 [code health] Handle browser autoplay blocking gracefully in NuUhUhEasterEgg

### DIFF
--- a/src/components/effects/Matrix/NuUhUhEasterEgg.tsx
+++ b/src/components/effects/Matrix/NuUhUhEasterEgg.tsx
@@ -82,7 +82,10 @@ export const NuUhUhEasterEgg = ({ onClose, id: _id }: NuUhUhEasterEggProps) => {
       try {
         await audioElement.play();
       } catch (error) {
-        console.warn("Audio playback failed", error);
+        // Autoplay may be blocked by the browser.
+        // We explicitly catch and swallow this expected error to prevent
+        // unhandled promise rejections, as this is a non-critical easter egg.
+        const _ = error;
       }
     };
 


### PR DESCRIPTION
🎯 **What:** 
Resolved a code health issue where an expected browser error (autoplay blocking in the NuUhUhEasterEgg) was being logged to `console.warn`. The error is now explicitly caught and swallowed.

💡 **Why:** 
Browser autoplay policies frequently block unprompted audio playback. Logging this as a warning creates unnecessary noise for an expected, non-critical event. Simply throwing the error causes an Unhandled Promise Rejection, which pollutes global error trackers. By assigning the error to a discard variable (`const _ = error`), we satisfy TypeScript/ESLint's unused variable checks while cleanly silencing the error.

✅ **Verification:** 
- Modified `NuUhUhEasterEgg.tsx` to handle the exception gracefully without `console.warn` or `throw`.
- Ran the full test suite (`pnpm test -- --watchAll=false`); all 174 tests across 39 suites passed successfully.
- Verified that the `biome lint ./src` command completes with 0 fixes needed and no warnings.

✨ **Result:** 
Cleaner console logs and improved error handling for non-critical browser behaviors, improving overall code health and maintainability.

---
*PR created automatically by Jules for task [2972420833314157716](https://jules.google.com/task/2972420833314157716) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Swallow expected audio autoplay blocking errors in the NuUhUhEasterEgg component instead of logging them or causing unhandled promise rejections.