### PR TITLE
🔒 [Fix] Secure CORS origin regex

### DIFF
--- a/src/server/apiCors.mjs
+++ b/src/server/apiCors.mjs
@@ -38,7 +38,7 @@ function buildCorsConfig(env = process.env) {
   for (const part of parts) {
     if (part.includes("*")) {
       const escaped = part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regexStr = `^${escaped.replace(/\\\*/g, "[a-zA-Z0-9-]{1,63}")}$`;
+      const regexStr = `^${escaped.replace(/\\\*/g, "[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?")}$`;
       regexes.push(new RegExp(regexStr));
     } else {
       exact.push(part);


### PR DESCRIPTION
🎯 **What**: The regex used to dynamically generate CORS validation for wildcard origins (`[a-zA-Z0-9-]{1,63}`) was overly permissive, allowing subdomains to start or end with a hyphen (which violates RFC 1035).

⚠️ **Risk**: While the risk is contained due to strict length boundaries preventing ReDoS, allowing non-compliant DNS labels in the regex string could theoretically lead to origin reflection anomalies or unexpected edge case validation bypasses depending on how downstream browsers interpret or coerce invalid origins.

🛡️ **Solution**: Replaced the permissive wildcard generation in `src/server/apiCors.mjs` with `[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?`. This stricter regex explicitly enforces that wildcards must start and end with alphanumeric characters, strictly conforming to valid DNS label requirements while maintaining the 63-character limit constraint. Tests were run to confirm there were no regressions.

---
*PR created automatically by Jules for task [2704235970531592825](https://jules.google.com/task/2704235970531592825) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Correct CORS origin wildcard regex to disallow subdomains starting or ending with a hyphen while preserving the existing length constraints.