### PR TITLE
🧹 Refactor Projects component state into useProjectsState hook

### DIFF
--- a/src/components/content/Projects/Projects.tsx
+++ b/src/components/content/Projects/Projects.tsx
@@ -123,7 +123,7 @@ interface ProjectsProps {
   db?: Pick<NotionData, "projects">;
 }
 
-function Projects({ db: propsDb }: ProjectsProps = {}) {
+function useProjectsState(propsDb?: Pick<NotionData, "projects">) {
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
   const [tagColors, setTagColors] = useState<Record<string, string>>({});
   const { db, isLoading } = useNotionSectionData(propsDb);
@@ -191,25 +191,57 @@ function Projects({ db: propsDb }: ProjectsProps = {}) {
     [activeFilters],
   );
 
-  const project_cards = projectsData.map((projectProps, index) => {
-    const primaryKeyword = projectProps.keywords[0] || "";
-    const primaryTagColor = tagColors[primaryKeyword];
-    const isFiltered =
-      projectProps.keywords.length > 0 &&
-      !projectProps.keywords.some((keyword) => activeFiltersSet.has(keyword));
-    const effect = createProjectEffect(primaryTagColor, index);
+  return useMemo(
+    () => ({
+      isLoading,
+      allKeywords,
+      activeFiltersSet,
+      tagColors,
+      toggleFilter,
+      projectsData,
+    }),
+    [
+      isLoading,
+      allKeywords,
+      activeFiltersSet,
+      tagColors,
+      toggleFilter,
+      projectsData,
+    ],
+  );
+}
 
-    return (
-      <ProjectCard
-        key={projectProps.slug}
-        {...projectProps}
-        tagColors={tagColors}
-        primaryTagColor={primaryTagColor}
-        className={isFiltered ? "filtered-out" : ""}
-        effect={effect}
-      />
-    );
-  });
+function Projects({ db: propsDb }: ProjectsProps = {}) {
+  const {
+    isLoading,
+    allKeywords,
+    activeFiltersSet,
+    tagColors,
+    toggleFilter,
+    projectsData,
+  } = useProjectsState(propsDb);
+
+  const projectCards = useMemo(() => {
+    return projectsData.map((projectProps, index) => {
+      const primaryKeyword = projectProps.keywords[0] || "";
+      const primaryTagColor = tagColors[primaryKeyword];
+      const isFiltered =
+        projectProps.keywords.length > 0 &&
+        !projectProps.keywords.some((keyword) => activeFiltersSet.has(keyword));
+      const effect = createProjectEffect(primaryTagColor, index);
+
+      return (
+        <ProjectCard
+          key={projectProps.slug}
+          {...projectProps}
+          tagColors={tagColors}
+          primaryTagColor={primaryTagColor}
+          className={isFiltered ? "filtered-out" : ""}
+          effect={effect}
+        />
+      );
+    });
+  }, [projectsData, tagColors, activeFiltersSet]);
 
   return (
     <div className="container" id="projects">
@@ -247,7 +279,7 @@ function Projects({ db: propsDb }: ProjectsProps = {}) {
             {isLoading ? (
               <NotionSectionSkeleton section="projects" />
             ) : (
-              project_cards
+              projectCards
             )}
           </div>
         </div>


### PR DESCRIPTION
🎯 **What:** Extracted complex state management, data derivation, and filtering logic from the `Projects` component into a dedicated `useProjectsState` hook within the same file.

💡 **Why:** The `Projects` component was overly complex, managing multiple responsibilities (state, effects, filtering, rendering). Abstracting state management to a separate custom hook isolates those concerns, significantly improving the readability, maintainability, and testability of the main presentation component, while keeping it focused purely on UI concerns.

✅ **Verification:** Verified by ensuring the `biome` formatter checks pass and running the component's test suite via `pnpm test src/components/content/Projects -- --watchAll=false`, ensuring no regressions in functionality, filtering logic, or tag color syncing occurred.

✨ **Result:** A simplified `Projects` component that relies on a cleanly decoupled custom hook. The codebase is now easier to understand, refactor, and extend.

---
*PR created automatically by Jules for task [9778005799707202270](https://jules.google.com/task/9778005799707202270) started by @guitarbeat*

## Summary by Sourcery

Refactor the Projects component by extracting its state, data derivation, and filtering logic into a dedicated useProjectsState hook, leaving Projects focused on rendering.

Enhancements:
- Introduce a useProjectsState hook to encapsulate projects data loading, filtering, and tag color state.
- Update the Projects component to consume the new hook and memoize the rendered project cards for clearer, more maintainable presentation logic.