### PR TITLE
🧹 Refactor HackTerminal to fix Overly Long Function

### DIFF
--- a/src/components/effects/Matrix/HackTerminal.tsx
+++ b/src/components/effects/Matrix/HackTerminal.tsx
@@ -14,124 +14,155 @@ interface HackTerminalProps {
   completionTelemetry: HackCompleteConsoleParams | null;
 }
 
-export function HackTerminal({
-  consoleDisplay,
-  hackFeedback,
-  hackInputRef,
-  hackProgress,
-  handleHackInputChange,
-  handleHackKeyDown,
-  handleViewportEngage,
+function getPhaseLabel(hackProgress: number): string {
+  if (hackProgress < 33) return "PHASE 1 // HACKING";
+  if (hackProgress < 66) return "PHASE 2 // DECRYPTING";
+  if (hackProgress < 100) return "PHASE 3 // ESCALATING";
+  return "ACCESS GRANTED";
+}
+
+function getChannelLabel(hackProgress: number): string {
+  if (hackProgress >= 100) return "SYSTEM READY";
+  if (hackProgress < 33) return "CHANNEL LOCKED";
+  if (hackProgress < 66) return "DECRYPTING";
+  return "CHANNEL OPEN";
+}
+
+function getFillClassName(hackProgress: number): string {
+  if (hackProgress < 33) return "is-critical";
+  if (hackProgress < 66) return "is-amber";
+  return "is-phosphor";
+}
+
+function getLineClassName(line: string): string {
+  let className = "hack-line";
+  if (line.includes("[ERR]") || line.includes("failed")) className += " error";
+  else if (line.includes("[WARN]")) className += " warn";
+  else if (line.includes("[SUCCESS]") || line.includes("[OK]"))
+    className += " success";
+  else if (line.startsWith("thumb@sys") || line.startsWith("root@"))
+    className += " prompt";
+  return className;
+}
+
+function HackTerminalStatus({
+  phaseLabel,
+  channelLabel,
+}: {
+  phaseLabel: string;
+  channelLabel: string;
+}) {
+  return (
+    <header className="hack-terminal-status">
+      <span className="hack-terminal-status__phase">{phaseLabel}</span>
+      <span className="hack-terminal-status__channel">{channelLabel}</span>
+    </header>
+  );
+}
+
+function HackSequencer({
   isHackComplete,
+  hackProgress,
+  hackFeedback,
+  progressScale,
+}: {
+  isHackComplete: boolean;
+  hackProgress: number;
+  hackFeedback: string;
+  progressScale: number;
+}) {
+  return (
+    <div className="hack-sequencer">
+      <div className="hack-sequencer__header">
+        <span className="hack-sequencer__title">
+          {isHackComplete ? "Hack complete" : "Hack in progress"}
+        </span>
+        <span className="hack-sequencer__percentage">
+          {Math.round(hackProgress)}%
+        </span>
+      </div>
+      <div
+        className="hack-sequencer__bar"
+        role="progressbar"
+        aria-valuenow={Math.round(hackProgress)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className="hack-sequencer__surge"
+          style={{ transform: `scaleX(${progressScale})` }}
+        />
+        <div
+          className={cn("hack-sequencer__fill", getFillClassName(hackProgress))}
+          style={{ transform: `scaleX(${progressScale})` }}
+        />
+      </div>
+      <p className="hack-sequencer__feedback">{hackFeedback}</p>
+    </div>
+  );
+}
+
+function HackViewport({
+  isHackComplete,
+  consoleDisplay,
   showConsoleCursor,
   completionTelemetry,
-}: HackTerminalProps) {
-  const phaseLabel =
-    hackProgress < 33
-      ? "PHASE 1 // HACKING"
-      : hackProgress < 66
-        ? "PHASE 2 // DECRYPTING"
-        : hackProgress < 100
-          ? "PHASE 3 // ESCALATING"
-          : "ACCESS GRANTED";
-
-  const progressScale = Math.min(1, Math.max(0, hackProgress / 100));
-
-  const channelLabel =
-    hackProgress < 100
-      ? hackProgress < 33
-        ? "CHANNEL LOCKED"
-        : hackProgress < 66
-          ? "DECRYPTING"
-          : "CHANNEL OPEN"
-      : "SYSTEM READY";
-
+  handleViewportEngage,
+}: {
+  isHackComplete: boolean;
+  consoleDisplay: string;
+  showConsoleCursor: boolean;
+  completionTelemetry: HackCompleteConsoleParams | null;
+  handleViewportEngage: () => void;
+}) {
   return (
-    <div className={cn("hack-terminal", isHackComplete && "complete")}>
-      <header className="hack-terminal-status">
-        <span className="hack-terminal-status__phase">{phaseLabel}</span>
-        <span className="hack-terminal-status__channel">{channelLabel}</span>
-      </header>
-
-      <div className="hack-sequencer">
-        <div className="hack-sequencer__header">
-          <span className="hack-sequencer__title">
-            {isHackComplete ? "Hack complete" : "Hack in progress"}
-          </span>
-          <span className="hack-sequencer__percentage">
-            {Math.round(hackProgress)}%
-          </span>
-        </div>
-        <div
-          className="hack-sequencer__bar"
-          role="progressbar"
-          aria-valuenow={Math.round(hackProgress)}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        >
-          <div
-            className="hack-sequencer__surge"
-            style={{ transform: `scaleX(${progressScale})` }}
-          />
-          <div
-            className={cn(
-              "hack-sequencer__fill",
-              hackProgress < 33
-                ? "is-critical"
-                : hackProgress < 66
-                  ? "is-amber"
-                  : "is-phosphor",
-            )}
-            style={{ transform: `scaleX(${progressScale})` }}
-          />
-        </div>
-        <p className="hack-sequencer__feedback">{hackFeedback}</p>
+    // biome-ignore lint/a11y/useSemanticElements: viewport layout uses role=button
+    <div
+      className={cn("hack-input__viewport", isHackComplete && "complete")}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") handleViewportEngage();
+      }}
+      onMouseDown={handleViewportEngage}
+      onTouchStart={handleViewportEngage}
+    >
+      <div className="hack-input__stream" aria-hidden="true">
+        {consoleDisplay.split("\n").map((line, index) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: log lines are append-only
+          <div key={index} className={getLineClassName(line)}>
+            {line}
+          </div>
+        ))}
+        {showConsoleCursor && <span className="hack-input__cursor" />}
       </div>
+      {isHackComplete && completionTelemetry && (
+        <output className="hack-success" aria-live="assertive">
+          <span className="hack-success__title">ACCESS GRANTED</span>
+          <span className="hack-success__meta">
+            Channel {completionTelemetry.signalChannel} ·{" "}
+            {completionTelemetry.runtimeDisplay}
+          </span>
+          <span className="hack-success__cta">&gt; PRESS ENTER OR ESC</span>
+        </output>
+      )}
+    </div>
+  );
+}
 
-      {/* biome-ignore lint/a11y/useSemanticElements: viewport layout uses role=button */}
-      <div
-        className={cn("hack-input__viewport", isHackComplete && "complete")}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ")
-            handleViewportEngage();
-        }}
-        onMouseDown={handleViewportEngage}
-        onTouchStart={handleViewportEngage}
-      >
-        <div className="hack-input__stream" aria-hidden="true">
-          {consoleDisplay.split("\n").map((line, index) => {
-            let className = "hack-line";
-            if (line.includes("[ERR]") || line.includes("failed"))
-              className += " error";
-            else if (line.includes("[WARN]")) className += " warn";
-            else if (line.includes("[SUCCESS]") || line.includes("[OK]"))
-              className += " success";
-            else if (line.startsWith("thumb@sys") || line.startsWith("root@"))
-              className += " prompt";
-
-            return (
-              // biome-ignore lint/suspicious/noArrayIndexKey: log lines are append-only
-              <div key={index} className={className}>
-                {line}
-              </div>
-            );
-          })}
-          {showConsoleCursor && <span className="hack-input__cursor" />}
-        </div>
-        {isHackComplete && completionTelemetry && (
-          <output className="hack-success" aria-live="assertive">
-            <span className="hack-success__title">ACCESS GRANTED</span>
-            <span className="hack-success__meta">
-              Channel {completionTelemetry.signalChannel} ·{" "}
-              {completionTelemetry.runtimeDisplay}
-            </span>
-            <span className="hack-success__cta">&gt; PRESS ENTER OR ESC</span>
-          </output>
-        )}
-      </div>
-
+function HackInput({
+  hackInputRef,
+  handleHackKeyDown,
+  handleHackInputChange,
+  isHackComplete,
+}: {
+  hackInputRef: React.RefObject<HTMLInputElement | null>;
+  handleHackKeyDown: (event: React.KeyboardEvent) => void;
+  handleHackInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  isHackComplete: boolean;
+}) {
+  return (
+    <>
       <input
         type="text"
         ref={hackInputRef}
@@ -154,6 +185,48 @@ export function HackTerminal({
           ? "Channel stabilized"
           : "Keep mashing to stabilize the signal"}
       </div>
+    </>
+  );
+}
+
+export function HackTerminal({
+  consoleDisplay,
+  hackFeedback,
+  hackInputRef,
+  hackProgress,
+  handleHackInputChange,
+  handleHackKeyDown,
+  handleViewportEngage,
+  isHackComplete,
+  showConsoleCursor,
+  completionTelemetry,
+}: HackTerminalProps) {
+  const phaseLabel = getPhaseLabel(hackProgress);
+  const channelLabel = getChannelLabel(hackProgress);
+  const progressScale = Math.min(1, Math.max(0, hackProgress / 100));
+
+  return (
+    <div className={cn("hack-terminal", isHackComplete && "complete")}>
+      <HackTerminalStatus phaseLabel={phaseLabel} channelLabel={channelLabel} />
+      <HackSequencer
+        isHackComplete={isHackComplete}
+        hackProgress={hackProgress}
+        hackFeedback={hackFeedback}
+        progressScale={progressScale}
+      />
+      <HackViewport
+        isHackComplete={isHackComplete}
+        consoleDisplay={consoleDisplay}
+        showConsoleCursor={showConsoleCursor}
+        completionTelemetry={completionTelemetry}
+        handleViewportEngage={handleViewportEngage}
+      />
+      <HackInput
+        hackInputRef={hackInputRef}
+        handleHackKeyDown={handleHackKeyDown}
+        handleHackInputChange={handleHackInputChange}
+        isHackComplete={isHackComplete}
+      />
     </div>
   );
 }


### PR DESCRIPTION
🎯 **What**
Refactored the `HackTerminal` component in `src/components/effects/Matrix/HackTerminal.tsx` to resolve the "Overly Long Function" code health issue.

💡 **Why**
The original `HackTerminal` component was monolithic (over 140 lines), mixing complex internal logic (multiple nested ternaries for phase/channel labels, line class generation) with extensive JSX markup. By extracting the pure functions (`getPhaseLabel`, `getChannelLabel`, `getFillClassName`, `getLineClassName`) and breaking down the UI into smaller sub-components (`HackTerminalStatus`, `HackSequencer`, `HackViewport`, `HackInput`), the code becomes vastly more readable, testable, and maintainable without changing any external behavior. The primary `HackTerminal` function is now only ~40 lines long.

✅ **Verification**
- Created a Python script to perform the exact refactoring safely.
- Verified the resulting file visually using `sed` to ensure the sub-components and the main wrapper were correctly formed.
- Ran `npx @biomejs/biome check --write` to ensure proper formatting and linting rules are followed.
- Executed the full test suite (`pnpm test -- --watchAll=false`); all 174 tests across 39 suites passed successfully, confirming no regressions in existing behavior.

✨ **Result**
A clean, modular `HackTerminal` implementation that eliminates the "Overly Long Function" warning and significantly improves the file's overall maintainability and structure.

---
*PR created automatically by Jules for task [2931835100402193851](https://jules.google.com/task/2931835100402193851) started by @guitarbeat*

## Summary by Sourcery

Refactor the HackTerminal component into smaller, focused pieces to improve readability and maintainability without changing its external behavior.

Enhancements:
- Extract pure helper functions for phase, channel, fill, and line classification logic from HackTerminal.
- Split HackTerminal UI into dedicated subcomponents for status, sequencer, viewport, and input while preserving existing behavior.