### PR TITLE
🧹 [Remove console.error from ErrorBoundary]

### DIFF
--- a/src/components/Core/ErrorBoundary.tsx
+++ b/src/components/Core/ErrorBoundary.tsx
@@ -36,7 +36,6 @@ class ErrorBoundary extends React.Component<
       error,
       errorInfo,
     });
-    console.error("ErrorBoundary caught an error:", error, errorInfo);
   }
 
   render() {


### PR DESCRIPTION
🎯 **What:** Removed the explicit `console.error` statement inside `componentDidCatch` in the `ErrorBoundary` component.
💡 **Why:** React automatically logs errors that are caught by an `ErrorBoundary` to the console. The manual `console.error` is redundant and triggers static analysis code health warnings. Removing it satisfies the warning and avoids double-logging the error in development, while preserving the error handling logic.
✅ **Verification:** Verified that the `console.error` line was removed correctly via `sed`. Also ran the full test suite (`pnpm test -- --watchAll=false`) which passed successfully, proving no regressions were introduced.
✨ **Result:** A cleaner ErrorBoundary component without redundant, hardcoded `console.error` logs that satisfies code health constraints.

---
*PR created automatically by Jules for task [554386458895893034](https://jules.google.com/task/554386458895893034) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Simplify the ErrorBoundary error handling by removing an explicit console.error call that duplicated React’s own logging.