### PR TITLE
🧪 Add missing error path tests for Notion snapshot KV operations

### DIFF
--- a/src/server/notion/__tests__/snapshot.test.js
+++ b/src/server/notion/__tests__/snapshot.test.js
@@ -48,6 +48,8 @@ describe("notion snapshot and health", () => {
       setJson: jest.fn().mockResolvedValue(undefined),
     };
 
+    const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+
     const result = await refreshContentSnapshot({
       fetchImpl,
       env: { NOTION_TOKEN: "test-token" },
@@ -80,6 +82,11 @@ describe("notion snapshot and health", () => {
         updatedAt: "2026-03-21T12:00:00.000Z",
       }),
     );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "[Notion KV] Successfully updated snapshot.",
+    );
+
+    consoleLogSpy.mockRestore();
   });
 
   it("throws an error when kvClient.setJson fails and requireSnapshotPersist is true", async () => {
@@ -90,10 +97,13 @@ describe("notion snapshot and health", () => {
         next_cursor: null,
       }),
     );
+    const mockError = new Error("KV write failed");
     const kvClient = {
       getJson: jest.fn(),
-      setJson: jest.fn().mockRejectedValue(new Error("KV write failed")),
+      setJson: jest.fn().mockRejectedValue(mockError),
     };
+
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
 
     await expect(
       refreshContentSnapshot({
@@ -104,6 +114,13 @@ describe("notion snapshot and health", () => {
         requireSnapshotPersist: true,
       }),
     ).rejects.toThrow("KV write failed");
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Notion KV] Failed to update snapshot:",
+      mockError,
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("swallows the error and returns snapshotStored=false when kvClient.setJson fails and requireSnapshotPersist is false", async () => {
@@ -114,10 +131,13 @@ describe("notion snapshot and health", () => {
         next_cursor: null,
       }),
     );
+    const mockError = new Error("KV write failed");
     const kvClient = {
       getJson: jest.fn(),
-      setJson: jest.fn().mockRejectedValue(new Error("KV write failed")),
+      setJson: jest.fn().mockRejectedValue(mockError),
     };
+
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
 
     const result = await refreshContentSnapshot({
       fetchImpl,
@@ -130,6 +150,12 @@ describe("notion snapshot and health", () => {
     expect(result.snapshotStored).toBe(false);
     expect(result.response.meta.snapshotUpdatedAt).toBeNull();
     expect(result.response.meta.source).toBe("live");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Notion KV] Failed to update snapshot:",
+      mockError,
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("returns the KV snapshot with degraded=true when live refresh fails", async () => {

--- a/src/server/notion/snapshot.mjs
+++ b/src/server/notion/snapshot.mjs
@@ -168,7 +168,9 @@ export async function refreshContentSnapshot({
       await kvClient.setJson(SNAPSHOT_KEY, snapshot);
       await kvClient.setJson(SNAPSHOT_META_KEY, snapshotMetadata);
       snapshotStored = true;
+      console.log("[Notion KV] Successfully updated snapshot.");
     } catch (error) {
+      console.error("[Notion KV] Failed to update snapshot:", error);
       if (requireSnapshotPersist) {
         throw error;
       }


### PR DESCRIPTION
🎯 **What:** Added missing error logging and tests for `refreshContentSnapshot` KV failure.\n📊 **Coverage:** The scenarios now tested include KV success logs and KV failure logs with both requireSnapshotPersist=true and false.\n✨ **Result:** Improved test coverage and reliability for Notion snapshot caching.

---
*PR created automatically by Jules for task [16898658416250502644](https://jules.google.com/task/16898658416250502644) started by @guitarbeat*

## Summary by Sourcery

Improve observability and error handling around Notion content snapshot KV persistence.

Enhancements:
- Log successful and failed KV snapshot update attempts for Notion content snapshots.

Tests:
- Extend snapshot tests to assert logging behavior on KV success and KV failures with requireSnapshotPersist both true and false.