### PR TITLE
🧹 Throw Error on persist Unlock storage failure

### DIFF
--- a/src/components/effects/Matrix/UnlockContext.tsx
+++ b/src/components/effects/Matrix/UnlockContext.tsx
@@ -101,9 +101,12 @@ const setSessionData = (key: string, value: unknown) => {
         Object.values(STORAGE_KEYS).forEach((k) => clearSessionData(k));
         window.sessionStorage.setItem(key, JSON.stringify(value));
       } catch (retryError) {
-        console.error(
-          `${ERROR_MESSAGES.STORAGE_ERROR} even after cleanup:`,
-          retryError,
+        throw new Error(
+          `${ERROR_MESSAGES.STORAGE_ERROR} even after cleanup: ${
+            retryError instanceof Error
+              ? retryError.message
+              : String(retryError)
+          }`,
         );
       }
     }

--- a/src/components/effects/Matrix/__tests__/UnlockContext.test.tsx
+++ b/src/components/effects/Matrix/__tests__/UnlockContext.test.tsx
@@ -95,21 +95,20 @@ describe("UnlockContext", () => {
       </UnlockProvider>,
     );
 
-    act(() => {
-      contextValue.completeHack();
-    });
+    expect(() => {
+      act(() => {
+        contextValue.completeHack();
+      });
+    }).toThrow(
+      `${ERROR_MESSAGES.STORAGE_ERROR} even after cleanup: ${quotaError.message}`
+    );
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining(ERROR_MESSAGES.STORAGE_ERROR),
       quotaError,
     );
 
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `${ERROR_MESSAGES.STORAGE_ERROR} even after cleanup:`,
-      ),
-      quotaError,
-    );
+    expect(errorSpy).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
     errorSpy.mockRestore();


### PR DESCRIPTION
🎯 **What:**
Modified `src/components/effects/Matrix/UnlockContext.tsx` to throw an error instead of logging it using `console.error` when a storage quota error persists after cleanup. Updated the corresponding test to expect the error.

💡 **Why:**
It is better to throw an error rather than just logging it, improving code health and predictability of the application.

✅ **Verification:**
Verified by running `npx @biomejs/biome check src/components/effects/Matrix/UnlockContext.tsx` and the test suite with `pnpm test src/components/effects/Matrix/__tests__/UnlockContext.test.tsx -- --watchAll=false` which passes.

✨ **Result:**
The storage quota error is now propagated properly by throwing an Error rather than being swallowed into a `console.error`.

---
*PR created automatically by Jules for task [11570696411886083228](https://jules.google.com/task/11570696411886083228) started by @guitarbeat*

## Summary by Sourcery

Propagate persistent session storage quota failures as thrown errors and align tests with the new behavior.

Enhancements:
- Throw an Error when session storage still fails after cleanup instead of logging to the console, ensuring the failure is surfaced to callers.

Tests:
- Update UnlockContext tests to expect an error to be thrown on persistent storage failures and to assert that console.error is not invoked.