### PR TITLE
🔒 Fix missing noopener on target="_blank" link

### DIFF
--- a/src/components/content/Projects/Projects.tsx
+++ b/src/components/content/Projects/Projects.tsx
@@ -58,7 +58,7 @@ function ProjectCard({
     <a
       href={link || undefined}
       target={link ? "_blank" : undefined}
-      rel={link ? "noreferrer" : undefined}
+      rel={link ? "noopener noreferrer" : undefined}
       className={cn(
         `projects__card ${className}`.trim(),
         image && "has-image",


### PR DESCRIPTION
🎯 **What**: Added `noopener` to the `rel` attribute alongside `noreferrer` for the `target="_blank"` anchor tag in `src/components/content/Projects/Projects.tsx`.
⚠️ **Risk**: A missing `noopener` on `target="_blank"` links can expose the site to reverse tabnabbing attacks, allowing a malicious linked page to redirect the original page or execute arbitrary scripts in the original page's context.
🛡️ **Solution**: By adding `noopener`, the newly opened page will run in a separate process, preventing it from having access to the `window.opener` object of the originating page, thus securing the site against this vulnerability.

---
*PR created automatically by Jules for task [4774206447223119615](https://jules.google.com/task/4774206447223119615) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Add the missing `noopener` value to the `rel` attribute for `target="_blank"` project links to prevent reverse tabnabbing.