### PR TITLE
🧹 [code health: use dedicated Logger in UnlockContext]

### DIFF
--- a/src/components/effects/Matrix/UnlockContext.tsx
+++ b/src/components/effects/Matrix/UnlockContext.tsx
@@ -11,7 +11,8 @@ import {
 
 // Hook imports
 import { useMobileDetection } from "@/hooks/useMobileDetection";
-
+// Utils
+import { Logger } from "@/utils/logger";
 // Constants
 import { ANIMATION_TIMING, ERROR_MESSAGES, UNLOCK } from "./constants";
 
@@ -69,7 +70,7 @@ const getSessionData = (key: string) => {
     const data = window.sessionStorage.getItem(key);
     return data ? JSON.parse(data) : null;
   } catch (error) {
-    console.warn(`${ERROR_MESSAGES.STORAGE_ERROR} for ${key}:`, error);
+    Logger.warn(`${ERROR_MESSAGES.STORAGE_ERROR} for ${key}:`, error);
     return null;
   }
 };
@@ -82,7 +83,7 @@ const clearSessionData = (key: string) => {
   try {
     window.sessionStorage.removeItem(key);
   } catch (error) {
-    console.warn(`${ERROR_MESSAGES.STORAGE_ERROR} for ${key}:`, error);
+    Logger.warn(`${ERROR_MESSAGES.STORAGE_ERROR} for ${key}:`, error);
   }
 };
 
@@ -94,14 +95,14 @@ const setSessionData = (key: string, value: unknown) => {
   try {
     window.sessionStorage.setItem(key, JSON.stringify(value));
   } catch (error) {
-    console.warn(`${ERROR_MESSAGES.STORAGE_ERROR} for ${key}:`, error);
+    Logger.warn(`${ERROR_MESSAGES.STORAGE_ERROR} for ${key}:`, error);
     if (error instanceof Error && error.name === "QuotaExceededError") {
       try {
         // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach used for side effect
         Object.values(STORAGE_KEYS).forEach((k) => clearSessionData(k));
         window.sessionStorage.setItem(key, JSON.stringify(value));
       } catch (retryError) {
-        console.error(
+        Logger.error(
           `${ERROR_MESSAGES.STORAGE_ERROR} even after cleanup:`,
           retryError,
         );

--- a/src/components/effects/Matrix/__tests__/UnlockContext.test.tsx
+++ b/src/components/effects/Matrix/__tests__/UnlockContext.test.tsx
@@ -1,5 +1,6 @@
 import { act, render } from "@testing-library/react";
 import { ERROR_MESSAGES } from "../constants";
+import { Logger } from "@/utils/logger";
 import { UnlockProvider, useUnlock } from "../UnlockContext";
 
 describe("UnlockContext", () => {
@@ -18,8 +19,8 @@ describe("UnlockContext", () => {
     };
 
     // Mock console.warn and console.error
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = jest.spyOn(Logger, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(Logger, "error").mockImplementation(() => {});
 
     // Mock sessionStorage.setItem to throw QuotaExceededError initially
     const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
@@ -78,8 +79,8 @@ describe("UnlockContext", () => {
       return null;
     };
 
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = jest.spyOn(Logger, "warn").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(Logger, "error").mockImplementation(() => {});
 
     const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
     const quotaError = new Error("Quota Exceeded");

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,13 @@
+export const Logger = {
+  warn: (message: string, ...args: unknown[]) => {
+    // Suppress noisy warnings in test environment unless specifically needed
+    if (process.env.NODE_ENV !== "test") {
+      console.warn(message, ...args);
+    }
+  },
+  error: (message: string, ...args: unknown[]) => {
+    if (process.env.NODE_ENV !== "test") {
+      console.error(message, ...args);
+    }
+  },
+};


### PR DESCRIPTION
🎯 **What:** Replaced raw `console.warn` and `console.error` calls with a dedicated `Logger` utility in `UnlockContext.tsx`.

💡 **Why:** Directly using `console.warn` for expected fallback mechanisms (like `QuotaExceededError` or privacy blocks in `sessionStorage`) pollutes the console and is generally frowned upon for code health. Abstracting it into a `Logger` allows us to suppress noisy warnings in test environments and gracefully degrade without crashing the app, unlike throwing errors which would cause critical regressions on app initialization.

✅ **Verification:** 
1. The new `Logger` utility suppresses output appropriately based on the environment.
2. Verified that the `UnlockContext.tsx` handles storage limits smoothly without unhandled exceptions.
3. Updated tests in `UnlockContext.test.tsx` to mock `Logger` rather than `console`.
4. Successfully ran `pnpm test -- --watchAll=false` and all tests passed.
5. Ran `npx @biomejs/biome check` to ensure code styles comply with linting rules.

✨ **Result:** Improved code health by centralizing logging and resolving raw console warnings in browser storage utilities.

---
*PR created automatically by Jules for task [6278564596135647087](https://jules.google.com/task/6278564596135647087) started by @guitarbeat*

## Summary by Sourcery

Centralize logging for UnlockContext session storage handling using a shared Logger utility that suppresses output in test environments.

Enhancements:
- Replace direct console.warn/console.error usage in UnlockContext session storage helpers with a shared Logger abstraction.
- Introduce a Logger utility that conditionally forwards warnings and errors to the console based on NODE_ENV to reduce noisy logs in tests.

Tests:
- Update UnlockContext tests to spy on and mock the Logger instead of the global console when verifying logging behavior.