### PR TITLE
🔒 Fix overly permissive CORS wildcard regex

### DIFF
--- a/src/server/apiCors.mjs
+++ b/src/server/apiCors.mjs
@@ -38,7 +38,13 @@ function buildCorsConfig(env = process.env) {
   for (const part of parts) {
     if (part.includes("*")) {
       const escaped = part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regexStr = `^${escaped.replace(/\\\*/g, "[a-zA-Z0-9-]{1,63}")}$`;
+      const regexStr =
+        "^" +
+        escaped.replace(
+          /\\\*/g,
+          "[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?",
+        ) +
+        "$";
       regexes.push(new RegExp(regexStr));
     } else {
       exact.push(part);


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the overly permissive CORS regex generation in `src/server/apiCors.mjs`. The wildcard `*` was replaced with `[a-zA-Z0-9-]{1,63}`, which could match malformed subdomains starting or ending with a hyphen (e.g. `https://-evil.example.com` or `https://evil-.example.com`).

⚠️ **Risk:** An attacker could potentially bypass the CORS allowed origins check by registering a domain that starts or ends with a hyphen, which is technically invalid for a domain name label, but could be processed in specific exploitation paths.

🛡️ **Solution:** Modify the regex replacement string from `[a-zA-Z0-9-]{1,63}` to `[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?`. This ensures the matched subdomain begins and ends with an alphanumeric character, correctly bounding the length while preventing leading or trailing hyphens. The string is constructed safely as `"^" + escaped.replace(/\\\*/g, "[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?") + "$"` to prevent syntax errors that occurred when nesting `{0,61}` inside a template literal containing other substitutions.

---
*PR created automatically by Jules for task [15769230760567865038](https://jules.google.com/task/15769230760567865038) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Correct CORS wildcard regex generation so that matched subdomain labels must start and end with an alphanumeric character while preserving valid length constraints.