### PR TITLE
🧹 Change Map to Maps in matrixRainIntensity JSDoc comment

### DIFF
--- a/src/components/effects/Matrix/matrixRainIntensity.ts
+++ b/src/components/effects/Matrix/matrixRainIntensity.ts
@@ -17,7 +17,7 @@ export interface MatrixRainDrawParams {
   brightHeadThreshold: number;
 }
 
-/** Map hack progress (0–100) to normalized rain intensity (0–1). */
+/** Maps hack progress (0–100) to normalized rain intensity (0–1). */
 export function getMatrixRainIntensity(progress: number): number {
   const range = 100 - ATTEMPT_START_PROGRESS;
   const t = clamp((progress - ATTEMPT_START_PROGRESS) / range, 0, 1);


### PR DESCRIPTION
🎯 **What**
Changed 'Map' to 'Maps' in the getMatrixRainIntensity JSDoc comment to prevent it from being incorrectly flagged as an actionable TODO.

💡 **Why**
The comment is descriptive, not an imperative task.

✅ **Verification**
Verified by reading the file and running the test suite.

✨ **Result**
The comment is now correctly phrased as a descriptive statement.

---
*PR created automatically by Jules for task [1572095865175326787](https://jules.google.com/task/1572095865175326787) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Clarify the matrix rain intensity function’s JSDoc description so it is correctly recognized as descriptive text rather than an actionable task.