### PR TITLE
🧪 Add tests for handlePrintfulError in shopUtils

### DIFF
--- a/src/utils/__tests__/shopUtils.test.ts
+++ b/src/utils/__tests__/shopUtils.test.ts
@@ -1,4 +1,71 @@
-import { parsePrintfulProduct } from "../shopUtils";
+import { parsePrintfulProduct, handlePrintfulError } from "../shopUtils";
+
+describe("handlePrintfulError", () => {
+  it("should return default error message for null/undefined", () => {
+    expect(handlePrintfulError(null)).toBe("API Error: Unknown Error");
+    expect(handlePrintfulError(undefined)).toBe("API Error: Unknown Error");
+  });
+
+  it("should handle string errors", () => {
+    expect(handlePrintfulError("Something went wrong")).toBe("API Error: undefined - Something went wrong");
+  });
+
+  it("should handle Error instances without response", () => {
+    const err = new Error("Standard error");
+    expect(handlePrintfulError(err)).toBe("API Error: undefined - Standard error");
+  });
+
+  it("should handle Error instances with response and statusText", () => {
+    const err = new Error("Standard error") as any;
+    err.response = { status: 404, statusText: "Not Found" };
+    expect(handlePrintfulError(err)).toBe("API Error: 404 - Not Found");
+  });
+
+  it("should handle Error instances with response but no statusText", () => {
+    const err = new Error("Standard error") as any;
+    err.response = { status: 500 };
+    expect(handlePrintfulError(err)).toBe("API Error: 500 - Standard error");
+  });
+
+  it("should handle Network Error messages (CORS) from Error instances", () => {
+    const err = new Error("Network Error");
+    expect(handlePrintfulError(err)).toBe("CORS Error: Unable to connect to Printful API. Please ensure the development server is running with the correct proxy configuration.");
+  });
+
+  it("should handle ERR_NETWORK codes (CORS) from Error instances", () => {
+    const err = new Error("Some error") as any;
+    err.code = "ERR_NETWORK";
+    expect(handlePrintfulError(err)).toBe("CORS Error: Unable to connect to Printful API. Please ensure the development server is running with the correct proxy configuration.");
+  });
+
+  it("should handle plain objects with message", () => {
+    expect(handlePrintfulError({ message: "Object error" })).toBe("API Error: undefined - Object error");
+  });
+
+  it("should handle plain objects with response and statusText", () => {
+    expect(handlePrintfulError({ response: { status: 500, statusText: "Internal Error" } })).toBe("API Error: 500 - Internal Error");
+  });
+
+  it("should handle plain objects with response, no statusText, but message", () => {
+    expect(handlePrintfulError({ response: { status: 500 }, message: "Fallback" })).toBe("API Error: 500 - Fallback");
+  });
+
+  it("should handle plain objects with response, no statusText, and no message", () => {
+    expect(handlePrintfulError({ response: { status: 500 } })).toBe("API Error: 500 - Unknown Error");
+  });
+
+  it("should handle plain objects with Network Error message", () => {
+    expect(handlePrintfulError({ message: "Network Error" })).toBe("CORS Error: Unable to connect to Printful API. Please ensure the development server is running with the correct proxy configuration.");
+  });
+
+  it("should handle plain objects with ERR_NETWORK code", () => {
+    expect(handlePrintfulError({ code: "ERR_NETWORK" })).toBe("CORS Error: Unable to connect to Printful API. Please ensure the development server is running with the correct proxy configuration.");
+  });
+
+  it("should respect custom context", () => {
+    expect(handlePrintfulError("Bad data", "Custom Context")).toBe("Custom Context: undefined - Bad data");
+  });
+});
 
 describe("parsePrintfulProduct", () => {
   it("should return default values for null product", () => {


### PR DESCRIPTION
🎯 **What:** Added comprehensive test suite for `handlePrintfulError` in `shopUtils.ts`.
📊 **Coverage:** Tests now cover string errors, Error instances (with/without response, fallback messages), plain objects (with/without response, statusText fallbacks), custom context strings, and CORS-specific network errors (Network Error, ERR_NETWORK) for both Error instances and objects.
✨ **Result:** Increased test coverage and ensured reliability of API error handling.

---
*PR created automatically by Jules for task [10718575314450432594](https://jules.google.com/task/10718575314450432594) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add comprehensive unit coverage for Printful API error handling across standard, response-based, fallback, custom-context, and CORS/network error scenarios.