### PR TITLE
🧪 Add tests for isMonthYear helper

### DIFF
--- a/src/server/notion/__tests__/helpers.test.js
+++ b/src/server/notion/__tests__/helpers.test.js
@@ -1,0 +1,29 @@
+import { isMonthYear } from "../helpers.mjs";
+
+describe("isMonthYear", () => {
+  it("returns true for valid MM-YYYY strings", () => {
+    expect(isMonthYear("01-2023")).toBe(true);
+    expect(isMonthYear("12-1999")).toBe(true);
+    expect(isMonthYear("99-9999")).toBe(true);
+  });
+
+  it("returns false for invalid string formats", () => {
+    expect(isMonthYear("1-2023")).toBe(false);
+    expect(isMonthYear("01/2023")).toBe(false);
+    expect(isMonthYear("2023-01")).toBe(false);
+    expect(isMonthYear(" 01-2023 ")).toBe(false);
+    expect(isMonthYear("01-2023a")).toBe(false);
+    expect(isMonthYear("a01-2023")).toBe(false);
+    expect(isMonthYear("123-2023")).toBe(false);
+    expect(isMonthYear("01-23")).toBe(false);
+  });
+
+  it("returns false for non-string inputs", () => {
+    expect(isMonthYear(null)).toBe(false);
+    expect(isMonthYear(undefined)).toBe(false);
+    expect(isMonthYear(122023)).toBe(false);
+    expect(isMonthYear({})).toBe(false);
+    expect(isMonthYear([])).toBe(false);
+    expect(isMonthYear(true)).toBe(false);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added missing tests for the isMonthYear validation helper in src/server/notion/helpers.mjs.\n📊 **Coverage:** Added coverage for valid MM-YYYY strings, various invalid string formats (e.g., missing digits, wrong separators, extra whitespace), and non-string types.\n✨ **Result:** Improved test coverage and reliability for Notion data validation.

---
*PR created automatically by Jules for task [13870319701836506904](https://jules.google.com/task/13870319701836506904) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add coverage for valid, malformed, and non-string inputs to the `isMonthYear` validation helper.