### PR TITLE
🧪 Add test for cleanupAudio

### DIFF
--- a/src/components/content/Header/Header.test.tsx
+++ b/src/components/content/Header/Header.test.tsx
@@ -27,7 +27,9 @@ describe("Header avatar", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-    jest.runOnlyPendingTimers();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
     jest.useRealTimers();
   });
 

--- a/src/components/effects/Matrix/__tests__/Matrix.benchmark.test.tsx
+++ b/src/components/effects/Matrix/__tests__/Matrix.benchmark.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import Matrix from "../Matrix";
 import { UnlockProvider } from "../UnlockContext";
@@ -56,15 +56,19 @@ describe("Matrix Performance", () => {
 
     // Trigger rapid resize events
     const resizeEvent = new Event("resize");
-    for (let i = 0; i < 10; i++) {
-      window.dispatchEvent(resizeEvent);
-    }
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        window.dispatchEvent(resizeEvent);
+      }
+    });
 
     // Immediately after events, it should NOT have been called due to debounce
     expect(widthSetterSpy).toHaveBeenCalledTimes(0);
 
     // Advance timers by debounce duration (200ms)
-    jest.advanceTimersByTime(200);
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
 
     // Now it should have been called EXACTLY once
     expect(widthSetterSpy).toHaveBeenCalledTimes(1);

--- a/src/utils/__tests__/audioUtils.test.ts
+++ b/src/utils/__tests__/audioUtils.test.ts
@@ -1,4 +1,4 @@
-import audioManager from "../audioUtils";
+import audioManager, { cleanupAudio } from "../audioUtils";
 
 describe("AudioManager", () => {
   let MockAudioContext: jest.Mock;
@@ -164,6 +164,18 @@ describe("AudioManager", () => {
         "File playback failed",
       );
       expect(handleAudioErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("cleanupAudio", () => {
+    it("should call audioManager.cleanup", () => {
+      const cleanupSpy = jest
+        .spyOn(audioManager, "cleanup")
+        .mockImplementation();
+
+      cleanupAudio();
+
+      expect(cleanupSpy).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `cleanupAudio` inside `audioUtils.ts`.
📊 **Coverage:** A new test scenario for `cleanupAudio` that ensures `audioManager.cleanup` is called.
✨ **Result:** Improved test coverage and reliability for audio manager cleanup functionality.

---
*PR created automatically by Jules for task [7294805422286014727](https://jules.google.com/task/7294805422286014727) started by @guitarbeat*

## Summary by Sourcery

Strengthen audio cleanup test coverage and make timer-based tests more reliable.

Enhancements:
- Add coverage verifying that audio cleanup delegates to the audio manager.
- Wrap timer and event-driven test operations in React `act` to ensure reliable state updates.

Tests:
- Expand audio utility tests to cover the `cleanupAudio` behavior.