### PR TITLE
🔒 Fix unescaped string variables in JSON.stringify() logging

### DIFF
--- a/api/content-refresh.mjs
+++ b/api/content-refresh.mjs
@@ -63,9 +63,10 @@ export default async function handler(req, res) {
       }),
     );
     console.error(
-      error instanceof Error
-        ? `Error: ${error.message}\nStack: ${error.stack}`
-        : String(error),
+      JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      }),
     );
 
     return res.status(error?.status || 500).json(payload);

--- a/api/content.mjs
+++ b/api/content.mjs
@@ -48,9 +48,10 @@ export default async function handler(req, res) {
       }),
     );
     console.error(
-      error instanceof Error
-        ? `Error: ${error.message}\nStack: ${error.stack}`
-        : String(error),
+      JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      }),
     );
 
     return res.status(error?.status || 500).json(payload);

--- a/api/health.mjs
+++ b/api/health.mjs
@@ -34,9 +34,10 @@ export default async function handler(req, res) {
   } catch (error) {
     res.setHeader("Cache-Control", "no-store");
     console.error(
-      error instanceof Error
-        ? `Error: ${error.message}\nStack: ${error.stack}`
-        : String(error),
+      JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      }),
     );
     return res.status(error?.status || 500).json(createErrorPayload(error));
   }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the use of unescaped string variables in error logging within `api/content.mjs`, `api/health.mjs`, and `api/content-refresh.mjs`.
⚠️ **Risk:** The potential impact if left unfixed includes log injection vulnerabilities, where an attacker might manipulate error messages or stack traces to insert malicious content into the logs. This can cause issues in log analysis tools or be used as part of a larger exploit chain to mislead monitoring systems.
🛡️ **Solution:** The solution involves using `JSON.stringify()` to safely encode the error messages and stack traces, ensuring that any potentially malicious string inputs are safely escaped and formatted as valid JSON data before being logged out via `console.error()`.

---
*PR created automatically by Jules for task [2269370754746798581](https://jules.google.com/task/2269370754746798581) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Safely encode error messages and stack traces in API logs to prevent log injection through malicious string content.