### PR TITLE
🧪 Add tests for vercelHost utils

### DIFF
--- a/src/components/content/Header/Header.test.tsx
+++ b/src/components/content/Header/Header.test.tsx
@@ -27,7 +27,9 @@ describe("Header avatar", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-    jest.runOnlyPendingTimers();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
     jest.useRealTimers();
   });
 

--- a/src/components/effects/Matrix/__tests__/Matrix.benchmark.test.tsx
+++ b/src/components/effects/Matrix/__tests__/Matrix.benchmark.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import Matrix from "../Matrix";
 import { UnlockProvider } from "../UnlockContext";
@@ -56,15 +56,19 @@ describe("Matrix Performance", () => {
 
     // Trigger rapid resize events
     const resizeEvent = new Event("resize");
-    for (let i = 0; i < 10; i++) {
-      window.dispatchEvent(resizeEvent);
-    }
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        window.dispatchEvent(resizeEvent);
+      }
+    });
 
     // Immediately after events, it should NOT have been called due to debounce
     expect(widthSetterSpy).toHaveBeenCalledTimes(0);
 
     // Advance timers by debounce duration (200ms)
-    jest.advanceTimersByTime(200);
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
 
     // Now it should have been called EXACTLY once
     expect(widthSetterSpy).toHaveBeenCalledTimes(1);

--- a/src/utils/__tests__/vercelHost.test.ts
+++ b/src/utils/__tests__/vercelHost.test.ts
@@ -1,0 +1,37 @@
+import { isVercelHostedBuild, SITE_ORIGIN } from "../vercelHost";
+
+describe("vercelHost", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe("isVercelHostedBuild", () => {
+    it('should return true when process.env.VERCEL is "1"', () => {
+      process.env.VERCEL = "1";
+      expect(isVercelHostedBuild()).toBe(true);
+    });
+
+    it('should return false when process.env.VERCEL is "0"', () => {
+      process.env.VERCEL = "0";
+      expect(isVercelHostedBuild()).toBe(false);
+    });
+
+    it("should return false when process.env.VERCEL is undefined", () => {
+      delete process.env.VERCEL;
+      expect(isVercelHostedBuild()).toBe(false);
+    });
+  });
+
+  describe("SITE_ORIGIN", () => {
+    it("should export the correct canonical production origin", () => {
+      expect(SITE_ORIGIN).toBe("https://woods.engineer");
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `isVercelHostedBuild` and `SITE_ORIGIN` in `src/utils/vercelHost.ts`
📊 **Coverage:** What scenarios are now tested: when process.env.VERCEL is "1", "0", and undefined.
✨ **Result:** The improvement in test coverage for `src/utils/vercelHost.ts`.

---
*PR created automatically by Jules for task [2687441707583933596](https://jules.google.com/task/2687441707583933596) started by @guitarbeat*

## Summary by Sourcery

Expand utility test coverage and stabilize related timer-driven tests.

Enhancements:
- Add coverage for Vercel hosting detection across enabled, disabled, and unset environment states, and verify the canonical site origin.

Tests:
- Improve test stability by wrapping timer advancement and event dispatches in React act boundaries.