### PR TITLE
🧹 Refactor constants export in split-notion-content.js archive script

### DIFF
--- a/scripts/archive/split-notion-content.js
+++ b/scripts/archive/split-notion-content.js
@@ -128,33 +128,25 @@ fs.writeFileSync(
   header('import { ContentError } from "./constants.js";', telemetry.trim()),
 );
 
-// Fix constants to export NOTION_API_BASE
+// Export constants that were previously internal to notionContent.js
 const constantsPath = path.join(outDir, "constants.js");
 let constantsBody = fs.readFileSync(constantsPath, "utf8");
-constantsBody = constantsBody.replace(
-  "const NOTION_API_BASE",
-  "export const NOTION_API_BASE",
-);
-constantsBody = constantsBody.replace(
-  "const NOTION_VERSION",
-  "export const NOTION_VERSION",
-);
+["NOTION_API_BASE", "NOTION_VERSION", "DATABASE_IDS"].forEach((name) => {
+  constantsBody = constantsBody.replace(
+    `const ${name}`,
+    `export const ${name}`,
+  );
+});
 fs.writeFileSync(constantsPath, constantsBody);
 
-// Export parseJsonSafely and toIsoString from helpers
+// Export helper functions that were previously internal to notionContent.js
 let helpersBody = fs.readFileSync(path.join(outDir, "helpers.js"), "utf8");
-helpersBody = helpersBody.replace(
-  "function parseJsonSafely",
-  "export function parseJsonSafely",
-);
-helpersBody = helpersBody.replace(
-  "function toIsoString",
-  "export function toIsoString",
-);
-helpersBody = helpersBody.replace(
-  "function extractRichText",
-  "export function extractRichText",
-);
+["parseJsonSafely", "toIsoString", "extractRichText"].forEach((name) => {
+  helpersBody = helpersBody.replace(
+    `function ${name}`,
+    `export function ${name}`,
+  );
+});
 fs.writeFileSync(path.join(outDir, "helpers.js"), helpersBody);
 
 const barrel = `export {


### PR DESCRIPTION
🎯 **What**
Updated `scripts/archive/split-notion-content.js` to iteratively export constants (`NOTION_API_BASE`, `NOTION_VERSION`, `DATABASE_IDS`) and helpers (`parseJsonSafely`, `toIsoString`, `extractRichText`) using a `.forEach` loop over array elements to simplify code structure and replace redundant replace statements.

💡 **Why**
The script was hard-coding the `const` -> `export const` replace statements for each constant. Iterating over an array of variable names keeps the file cleaner and easier to maintain. Furthermore, this correctly exports `DATABASE_IDS` along with the other variables.

✅ **Verification**
Verified through `pnpm test` and `git diff` that the correct files have been updated and tests pass.

✨ **Result**
Code structure in the archive script is simpler and more organized.

---
*PR created automatically by Jules for task [6462460428184019968](https://jules.google.com/task/6462460428184019968) started by @guitarbeat*

## Summary by Sourcery

Simplify the archive script’s generated exports and include DATABASE_IDS in the exported constants.

Bug Fixes:
- Ensure DATABASE_IDS is exported alongside the other generated constants.

Enhancements:
- Simplify generated constant and helper exports by applying them through reusable name lists.